### PR TITLE
refactor(dependabot): use ora spinners for consistent loading pattern

### DIFF
--- a/src/commands/dependabot/merge.js
+++ b/src/commands/dependabot/merge.js
@@ -320,13 +320,14 @@ export async function mergeAction (options) {
   const summary = { merged: [], errored: [] }
 
   for (const entry of selected) {
+    const spinner = ora({ text: `${entry.repo}#${entry.pr} — approving and merging` }).start()
     try {
       await approvePr(owner, entry.repo, entry.pr)
       await mergePr(owner, entry.repo, entry.pr)
-      console.log(green(`  ✓ ${entry.repo}#${entry.pr} — approved and merged`))
+      spinner.succeed(`${entry.repo}#${entry.pr} — approved and merged`)
       summary.merged.push(entry)
     } catch (err) {
-      console.log(red(`  ✗ ${entry.repo}#${entry.pr} — ${err.message}`))
+      spinner.fail(`${entry.repo}#${entry.pr} — ${err.message}`)
       summary.errored.push({ ...entry, error: err.message })
     }
   }

--- a/src/commands/dependabot/rebase.js
+++ b/src/commands/dependabot/rebase.js
@@ -1,3 +1,4 @@
+import ora from 'ora'
 import { $ } from '../../core/exec.js'
 import { info } from '../../core/patch-console-log.js'
 
@@ -15,15 +16,20 @@ export async function rebaseAction (options) {
 
   for (const pr of prs) {
     const { number, author } = pr
-    info(`Processing PR #${number} by ${author.login}...`)
-
     const botName = author.login.toLowerCase().includes('dependabot') ? 'dependabot' : 'renovate'
-    await $(`gh pr comment ${number} --body @${botName}\\ rebase`)
 
-    if (options.merge) {
-      await $(`gh pr merge ${number} --auto --squash`).catch((error) => {
-        info(`Failed to merge PR #${number}.`, error.message)
-      })
+    const spinner = ora({ text: `PR #${number} by ${author.login} — commenting @${botName} rebase` }).start()
+    try {
+      await $(`gh pr comment ${number} --body @${botName}\\ rebase`, { loading: false, disableLog: true })
+
+      if (options.merge) {
+        spinner.text = `PR #${number} by ${author.login} — enabling auto-merge`
+        await $(`gh pr merge ${number} --auto --squash`, { loading: false, disableLog: true })
+      }
+
+      spinner.succeed(`PR #${number} by ${author.login} — done`)
+    } catch (err) {
+      spinner.fail(`PR #${number} by ${author.login} — ${err.message}`)
     }
   }
 


### PR DESCRIPTION
<!-- markdownlint-configure-file
{
  "MD033": false,
  "MD036": false,
  "MD041": false
}
-->

✅ Closes

- N/A

✋ publicar antes deste pr

- N/A

⏭️ publicar depois deste pr

- N/A

**Checklist**

- [ ] Fieldnews - enviar broadcast via e-mail com publicação
- [ ] 🧪 Testes - testes e2e, integrados e unitários foram feitos

<!-- Init:FieldnewsEmailContent -->

**Contexto**

Os comandos `field dependabot merge` e `field dependabot rebase` usavam `console.log` com emojis para indicar progresso, diferente do padrão `ora` spinner usado nos demais comandos do CLI.

**Motivações**

Manter consistência visual entre todos os comandos. O padrão `ora` com `.succeed()`/`.fail()` já é usado pelo helper `$()` e pelo comando `merge`, então os comandos dependabot deviam seguir o mesmo estilo.

**Implementação**

- `merge.js`: trocou `console.log` com ✓/✗ por `ora` spinner com `.succeed()`/`.fail()` no loop de approve+merge.
- `rebase.js`: adicionou `ora` spinner por PR, com `loading: false` e `disableLog: true` nos `$()` internos para evitar spinners duplicados.

**Evoluções**

Feedback visual mais consistente e limpo em todos os comandos do CLI.

**Screenshots**

N/A — mudança apenas no output do terminal.

<!-- End:FieldnewsEmailContent -->
