### PR TITLE
fix(dependabot): fallback to commit message for version bump detection

### DIFF
--- a/src/commands/dependabot/merge.js
+++ b/src/commands/dependabot/merge.js
@@ -35,15 +35,39 @@ function isManifestFile (filename) {
   return false
 }
 
-function parseVersionBump (title) {
-  const match = title.match(/from\s+v?(\d+)\.(\d+)\.(\d+)\s+to\s+v?(\d+)\.(\d+)\.(\d+)/i)
+function parseVersionBumpFromText (text) {
+  // Match semver (1.2.3), two-part (1.2), or single-digit (4) versions
+  const match = text.match(/from\s+v?(\d+)(?:\.(\d+))?(?:\.(\d+))?\s+to\s+v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/i)
   if (!match) return 'unknown'
 
-  const [, oldMaj, oldMin, , newMaj, newMin] = match.map(Number)
+  const [, oldMaj, oldMin, oldPatch, newMaj, newMin, newPatch] = match.map(v => v !== undefined ? Number(v) : undefined)
 
   if (oldMaj !== newMaj) return 'major'
   if (oldMin !== newMin) return 'minor'
-  return 'patch'
+  if (oldPatch !== newPatch) return 'patch'
+  return 'unknown'
+}
+
+function parseVersionBumpFromMetadata (text) {
+  const updateTypes = [...text.matchAll(/update-type:\s*version-update:semver-(\w+)/g)]
+    .map(m => m[1])
+
+  if (updateTypes.length === 0) return 'unknown'
+  if (updateTypes.includes('major')) return 'major'
+  if (updateTypes.includes('minor')) return 'minor'
+  if (updateTypes.every(t => t === 'patch')) return 'patch'
+  return 'unknown'
+}
+
+function parseVersionBump (title, commitMessage) {
+  const bump = parseVersionBumpFromText(title)
+  if (bump !== 'unknown') return bump
+  if (commitMessage) {
+    const fromText = parseVersionBumpFromText(commitMessage)
+    if (fromText !== 'unknown') return fromText
+    return parseVersionBumpFromMetadata(commitMessage)
+  }
+  return 'unknown'
 }
 
 function isGitHubAction (title) {
@@ -61,8 +85,8 @@ function isDevelopmentDep (title) {
   return devPatterns.some(p => lower.includes(p))
 }
 
-function assessRisk (pr, ciStatus, onlyManifestFiles) {
-  const bump = parseVersionBump(pr.title)
+function assessRisk (pr, ciStatus, onlyManifestFiles, commitMessage) {
+  const bump = parseVersionBump(pr.title, commitMessage)
   const isAction = isGitHubAction(pr.title)
   const isDev = isDevelopmentDep(pr.title)
   const ciPassing = ciStatus === 'passing'
@@ -151,6 +175,20 @@ async function getCiStatus (owner, repoName, ref) {
   }
 }
 
+async function getFirstCommitMessage (owner, repoName, prNumber) {
+  try {
+    const { data } = await getOctokit().rest.pulls.listCommits({
+      owner,
+      repo: repoName,
+      pull_number: prNumber,
+      per_page: 1
+    })
+    return data[0]?.commit?.message || ''
+  } catch {
+    return ''
+  }
+}
+
 async function getChangedFiles (owner, repoName, prNumber) {
   const { data } = await getOctokit().rest.pulls.listFiles({
     owner,
@@ -226,13 +264,14 @@ async function scanPrs (owner, repos) {
     spinner.succeed(`${repo.name} — ${dependabotPrs.length} Dependabot PR(s)`)
 
     for (const pr of dependabotPrs) {
-      const [ci, files] = await Promise.all([
+      const [ci, files, commitMessage] = await Promise.all([
         getCiStatus(owner, repo.name, pr.head.sha),
-        getChangedFiles(owner, repo.name, pr.number)
+        getChangedFiles(owner, repo.name, pr.number),
+        getFirstCommitMessage(owner, repo.name, pr.number)
       ])
 
       const onlyManifest = files.every(f => isManifestFile(f))
-      const assessment = assessRisk(pr, ci.status, onlyManifest)
+      const assessment = assessRisk(pr, ci.status, onlyManifest, commitMessage)
 
       const riskColor = assessment.risk === 'low'
         ? green


### PR DESCRIPTION
<!-- markdownlint-configure-file
{
  "MD033": false,
  "MD036": false,
  "MD041": false
}
-->

✅ Closes

- N/A

✋ publicar antes deste pr

- N/A

⏭️ publicar depois deste pr

- N/A

**Checklist**

- [ ] Fieldnews - enviar broadcast via e-mail com publicação
- [x] 🧪 Testes - testes e2e, integrados e unitários foram feitos

<!-- Init:FieldnewsEmailContent -->

**Contexto**

O comando `dependabot merge` classifica PRs do Dependabot por risco (low/medium/high) com base no tipo de bump de versão (patch/minor/major) extraído do título do PR.

**Motivações**

PRs agrupados do Dependabot (ex: [palantir#1065](https://github.com/FieldControl/palantir/pull/1065)) não incluem versões no título — o título é algo como "bump the github-actions group with 5 updates". Isso fazia o parser retornar `unknown`, classificando o PR como `medium` risk mesmo quando poderia ser avaliado corretamente.

**Implementação**

Três mudanças:

1. **Fallback para commit message** — quando o título não contém versão, busca a mensagem do primeiro commit do PR via API do GitHub e tenta extrair a versão de lá.
2. **Parse de metadados do Dependabot** — o commit body dos PRs agrupados contém metadata estruturada como `update-type: version-update:semver-major`. Adicionada função `parseVersionBumpFromMetadata` que extrai o maior bump entre todas as dependências listadas.
3. **Suporte a versões de um dígito** — a regex agora aceita versões como `4`, `1.2`, e `1.2.3` (antes só aceitava `X.Y.Z`).

**Evoluções**

- PRs agrupados do Dependabot agora são classificados corretamente por risco
- PRs de GitHub Actions com versões de dígito único (ex: "from 4 to 6") agora são detectados como major bumps

**Screenshots**

N/A — mudança em CLI sem interface visual.

<!-- End:FieldnewsEmailContent -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
