### PR TITLE
feat(repo-clean): add worktree support and auto-remove worktrees

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,7 @@
     "Trevizam",
     "vercel",
     "VERCEL",
-    "viniciusfantoli"
+    "viniciusfantoli",
+    "worktree"
   ]
 }

--- a/src/commands/repo-clean/index.js
+++ b/src/commands/repo-clean/index.js
@@ -31,8 +31,17 @@ class RepoCleanCommand {
       return match ? match[1] : 'master'
     })
 
-    await $(`git checkout ${baseBranch}`)
-    await $(`git pull origin ${baseBranch}`)
+    const workTrees = await listWorkTrees()
+    const workTreeBranches = new Set(workTrees.map((w) => w.branch).filter(Boolean))
+    const baseWorkTree = workTrees.find((w) => w.branch === baseBranch)
+    const runningFromWorkTree = workTrees.some((w) => w.path === process.cwd() && !w.isMain)
+
+    if (baseWorkTree) {
+      await $(`git pull origin ${baseBranch}`, { cwd: baseWorkTree.path })
+    } else {
+      await $(`git checkout ${baseBranch}`)
+      await $(`git pull origin ${baseBranch}`)
+    }
 
     const branches = await $('git branch')
       .then((output) => output.split('\n'))
@@ -40,6 +49,7 @@ class RepoCleanCommand {
       .then((branches) => branches.filter((branch) => branch !== ''))
       .then((branches) => branches.filter((branch) => branch.startsWith('*') === false))
       .then((branches) => branches.filter((branch) => branch.startsWith('+') === false))
+      .then((branches) => branches.filter((branch) => !workTreeBranches.has(branch)))
       .then((branches) => branches.filter((branch) => branch !== baseBranch))
       .then((branches) => branches.filter((branch) => !branch.startsWith(baseBranch)))
       .then((branches) => branches.filter((branch) => branch !== 'homolog'))
@@ -56,7 +66,16 @@ class RepoCleanCommand {
       }
     }
 
-    await $(`git checkout ${baseBranch}`)
+    if (!runningFromWorkTree) {
+      await $(`git checkout ${baseBranch}`)
+    }
+
+    const removableWorkTrees = workTrees.filter((w) => !w.isMain && w.path !== process.cwd())
+    for (const workTree of removableWorkTrees) {
+      info(`Removing worktree ${workTree.path}${workTree.branch ? ` (${workTree.branch})` : ''}`)
+      await $(`git worktree remove ${workTree.path}`)
+      if (workTree.branch) workTreeBranches.delete(workTree.branch)
+    }
 
     const mergedBranches = await $(`git branch --merged ${baseBranch}`)
       .then((output) => output.split('\n'))
@@ -65,6 +84,7 @@ class RepoCleanCommand {
       .then((branches) => branches.filter((branch) => branch !== ''))
       .then((branches) => branches.filter((branch) => branch.startsWith('*') === false))
       .then((branches) => branches.filter((branch) => branch.startsWith('+') === false))
+      .then((branches) => branches.filter((branch) => !workTreeBranches.has(branch)))
       .then((branches) => branches.filter((branch) => branch !== baseBranch))
       .then((branches) => branches.filter((branch) => branch !== 'preview'))
       .then((branches) => branches.filter((branch) => branch !== 'homolog'))
@@ -112,6 +132,29 @@ class RepoCleanCommand {
       }
     }
   }
+}
+
+async function listWorkTrees () {
+  const output = await $('git worktree list --porcelain', { disableLog: true, loading: false })
+  if (typeof output !== 'string' || output === '') return []
+
+  const workTrees = []
+  let current = {}
+  for (const line of output.split('\n')) {
+    if (line === '') {
+      if (current.path) workTrees.push(current)
+      current = {}
+      continue
+    }
+    const [key, ...rest] = line.split(' ')
+    const value = rest.join(' ')
+    if (key === 'worktree') current.path = value
+    else if (key === 'branch') current.branch = value.replace('refs/heads/', '')
+  }
+  if (current.path) workTrees.push(current)
+
+  if (workTrees.length > 0) workTrees[0].isMain = true
+  return workTrees
 }
 
 export default new RepoCleanCommand()


### PR DESCRIPTION
✅ Closes

- N/A

✋ publicar antes deste pr

- N/A

⏭️ publicar depois deste pr

- N/A

**Checklist**

- [ ] Fieldnews - enviar broadcast via e-mail com publicação
- [ ] 🧪 Testes - testes e2e, integrados e unitários foram feitos

**Contexto**

O comando `field repo clean` faz limpeza de branches locais/remotos no repositório atual: rebaseia branches em cima da `master`, deleta branches já mergeados e oferece deletar branches remotos mergeados. Antes ele tinha problemas quando o repositório usava `git worktree`: o `git checkout master` falhava se a `master` estivesse em outra worktree, e branches de worktrees podiam aparecer nas listas de candidatos a deleção.

**Motivações**

Hoje uso git worktrees no dia a dia (agentes paralelos, etc.) e o `repo clean` quebrava nesses cenários. A correção anterior (#368) só ignorava branches prefixadas com `+`, mas não dava suporte real a worktrees (não funcionava rodando *de dentro* de uma worktree e não removia worktrees obsoletas).

**Implementação**

- Novo helper `listWorkTrees()` parseia `git worktree list --porcelain` e devolve `{ path, branch, isMain }` de cada worktree.
- O conjunto `workTreeBranches` é usado para filtrar branches checked-out em worktrees das listas de rebase e de deleção local — substitui o filtro frágil baseado em `+`.
- Se a `baseBranch` está em outra worktree, o `git pull` é executado lá via `cwd` em vez de tentar `git checkout` (que falharia).
- Quando rodando de dentro de uma worktree, o `git checkout ${baseBranch}` intermediário é pulado.
- Após o loop de rebase, todas as worktrees adicionais (não-principais e diferentes da atual) são removidas com `git worktree remove`. O branch é mantido — só o diretório de trabalho é apagado.
- Adicionada palavra `worktree` ao dicionário do cSpell em `.vscode/settings.json`.

**Evoluções**

- `repo clean` agora funciona corretamente quando rodado de dentro de uma worktree.
- Limpeza automática de worktrees adicionais reduz acúmulo de diretórios obsoletos sem perder branches.
- Filtro mais robusto de branches em uso (não depende mais de heurística textual `+`).

**Screenshots**

N/A — mudança de CLI sem UI.
