### PR TITLE
chore(deps): allow build scripts for unrs-resolver@1.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,8 @@
     "openai": "6.46.0",
     "ora": "9.4.1",
     "yaml": "2.8.4"
+  },
+  "allowScripts": {
+    "unrs-resolver@1.11.1": true
   }
 }


### PR DESCRIPTION
<!-- markdownlint-configure-file
{
  "MD033": false,
  "MD036": false,
  "MD041": false
}
-->

✅ Closes

- N/A

**Checklist**

- [ ] Fieldnews - enviar broadcast via e-mail com publicação
- [x] 🧪 Testes - testes e2e, integrados e unitários foram feitos

<!-- Init:FieldnewsEmailContent -->

**Contexto**

O `fc-tools` usa o `npm` moderno, que por padrão bloqueia a execução de scripts de instalação (`postinstall`, `install`, etc.) de dependências que não estejam explicitamente autorizadas. Isso é uma proteção contra pacotes maliciosos que tentam rodar código na hora do `npm install`.

**Motivações**

A dependência `unrs-resolver@1.11.1` (usada na cadeia de resolução de módulos do ecossistema de lint) precisa rodar um script de instalação para funcionar corretamente. Sem a autorização, o script fica bloqueado e o pacote pode não operar como esperado.

**Implementação**

Adicionado um bloco `allowScripts` no `package.json` autorizando explicitamente a execução do script de instalação do `unrs-resolver@1.11.1`:

```json
"allowScripts": {
  "unrs-resolver@1.11.1": true
}
```

**Evoluções**

Garante que o script de instalação necessário rode de forma autorizada e auditável, sem afrouxar a política geral de bloqueio de scripts para outras dependências.

<!-- End:FieldnewsEmailContent -->
