### PR TITLE
chore: rename project from fc-tools to theo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,7 @@
     "sidemenu",
     "Solicitaçõ",
     "tauk",
+    "theo",
     "Trevizam",
     "viniciusfantoli",
     "worktree"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`fc-tools` is an ESM Node.js CLI toolkit (`field` binary) for Field Control developer workflows. It automates Git operations, GitHub PR management, and integration with the Flux project management tool.
+`theo` is an ESM Node.js CLI toolkit (`theo` binary) for Field Control developer workflows. It automates Git operations, GitHub PR management, and integration with the Flux project management tool.
 
 ## Commands
 
@@ -15,7 +15,7 @@ npm run lint                # Lint with ESLint
 npm run lint:fix            # Auto-fix lint issues
 ```
 
-The CLI itself is run via `field <command>` after installation, or directly with `node src/index.js <command>` during development.
+The CLI itself is run via `theo <command>` after installation, or directly with `node src/index.js <command>` during development.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FC Tools
+# Theo
 
 Kit com ferramentas e scripts para fluxos de trabalhos de desenvolvedores da field control
 
@@ -21,9 +21,9 @@ Siga as instruções no terminal até completar o login
 **Instalação com script de uma linha**
 
   ```sh
-  curl https://raw.githubusercontent.com/LeoFalco/fc-tools/master/scripts/install.sh -s | sh
+  curl https://raw.githubusercontent.com/LeoFalco/theo/master/scripts/install.sh -s | sh
   ```
 
 ## Resumo dos comandos disponíveis
 
-- `field --help` mostra ajuda e lista comandos disponíveis
+- `theo --help` mostra ajuda e lista comandos disponíveis

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "fc-tools",
+  "name": "theo",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fc-tools",
+      "name": "theo",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "fc-tools",
+  "name": "theo",
   "version": "1.0.0",
   "description": "Kit com ferramentas e scripts para fluxos de trabalhos de desenvolvedores da field control",
   "main": "src/index.js",
   "type": "module",
   "bin": {
-    "field": "src/index.js"
+    "theo": "src/index.js"
   },
   "scripts": {
     "test": "node --test",
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/LeoFalco/fc-tools.git"
+    "url": "git+https://github.com/LeoFalco/theo.git"
   },
   "keywords": [
     "cli",
@@ -27,9 +27,9 @@
   "author": "leonardo.falco@outlook.com",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/LeoFalco/fc-tools/issues"
+    "url": "https://github.com/LeoFalco/theo/issues"
   },
-  "homepage": "https://github.com/LeoFalco/fc-tools#readme",
+  "homepage": "https://github.com/LeoFalco/theo#readme",
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@stylistic/eslint-plugin": "5.10.0",

--- a/prompts/pr.md
+++ b/prompts/pr.md
@@ -32,4 +32,4 @@ description: Git workflow specialist. Adds, commits, creates branch, and opens P
 
 
 4. **Finalização**:
-* Execute o comando: `field pr-create --branch <branch-name> --message "<commit-message>" --body-file pr-body.md`.
+* Execute o comando: `theo pr-create --branch <branch-name> --message "<commit-message>" --body-file pr-body.md`.

--- a/scripts/alias.fish.sh
+++ b/scripts/alias.fish.sh
@@ -1,10 +1,10 @@
-function field
-  nvm use (cat ~/.fc-tools/.nvmrc) >> /dev/null
-  node --no-deprecation ~/.fc-tools $argv
+function theo
+  nvm use (cat ~/.theo/.nvmrc) >> /dev/null
+  node --no-deprecation ~/.theo $argv
   nvm use &> /dev/null
 end
 
 
-function field-update
-  curl https://raw.githubusercontent.com/LeoFalco/fc-tools/master/scripts/install.sh -s | sh
+function theo-update
+  curl https://raw.githubusercontent.com/LeoFalco/theo/master/scripts/install.sh -s | sh
 end

--- a/scripts/alias.sh
+++ b/scripts/alias.sh
@@ -1,9 +1,9 @@
-function field () {
-  nvm use $(cat ~/.fc-tools/.nvmrc) >> /dev/null
-  node --no-warnings ~/.fc-tools $@
+function theo () {
+  nvm use $(cat ~/.theo/.nvmrc) >> /dev/null
+  node --no-warnings ~/.theo $@
   nvm use &> /dev/null
 }
 
-function field-update () {
-  curl https://raw.githubusercontent.com/LeoFalco/fc-tools/master/scripts/install.sh -s | sh
+function theo-update () {
+  curl https://raw.githubusercontent.com/LeoFalco/theo/master/scripts/install.sh -s | sh
 }

--- a/scripts/install.prompts.sh
+++ b/scripts/install.prompts.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source_dir="$HOME/.fc-tools/prompts"
+source_dir="$HOME/.theo/prompts"
 target_dir="$HOME/.gemini/antigravity/global_workflows"
 
 mkdir -p "$(dirname "$target_dir")"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,29 +1,48 @@
 #! usr/bin/sh
 
-echo "▷ Installing fc-tools..."
+echo "▷ Installing theo..."
 
-# if fc-tools directory not exists
-if [ ! -d ~/.fc-tools ]; then
-  echo "▷ Cloning fc-tools..."
-  git clone https://github.com/LeoFalco/fc-tools.git ~/.fc-tools --depth 1
-  echo "▷ Cloned fc-tools."
+# migrate from the old fc-tools installation
+migrate_rc_file() {
+  rc_file=$1
+  [ -f "$rc_file" ] || return 0
+  if grep -q "\.fc-tools" "$rc_file"; then
+    echo "▷ Removing old fc-tools entries from $rc_file..."
+    sed -i.bak '/\.fc-tools/d' "$rc_file"
+    echo "▷ Removed old fc-tools entries from $rc_file (backup at $rc_file.bak)."
+  fi
+}
+
+migrate_rc_file ~/.bashrc
+migrate_rc_file ~/.zshrc
+migrate_rc_file ~/.config/fish/config.fish
+
+if [ -d ~/.fc-tools ]; then
+  echo "▷ The old ~/.fc-tools directory is no longer used and can be removed with 'rm -rf ~/.fc-tools'."
+fi
+
+# if theo directory not exists
+if [ ! -d ~/.theo ]; then
+  echo "▷ Cloning theo..."
+  git clone https://github.com/LeoFalco/theo.git ~/.theo --depth 1
+  echo "▷ Cloned theo."
 else
-  echo "▷ fc-tools already cloned."
-  cd ~/.fc-tools
-  echo "▷ Updating fc-tools..."
+  echo "▷ theo already cloned."
+  cd ~/.theo
+  echo "▷ Updating theo..."
 
   git fetch --all >> /dev/null
   git reset --hard origin/master
   git pull
 
-  echo "▷ Updated fc-tools."
+  echo "▷ Updated theo."
   cd - >> /dev/null
 fi
 
 . ~/.nvm/nvm.sh
-nvm use $(cat ~/.fc-tools/.nvmrc) || nvm install $(cat ~/.fc-tools/.nvmrc)
+nvm use $(cat ~/.theo/.nvmrc) || nvm install $(cat ~/.theo/.nvmrc)
 
-cd ~/.fc-tools
+cd ~/.theo
 echo "▷ Installing dependencies..."
 npm install >> /dev/null
 echo "▷ Installed dependencies."
@@ -32,36 +51,35 @@ git reset --hard >> /dev/null
 cd - >> /dev/null
 
 if [ -f ~/.bashrc ]; then
-  if ! grep -q "fc-tools" ~/.bashrc; then
-    echo "▷ Adding fc-tools to bashrc..."
-    echo "\nsource ~/.fc-tools/scripts/alias.sh" >> ~/.bashrc
-    echo "▷ Added fc-tools to bashrc."
+  if ! grep -q "\.theo" ~/.bashrc; then
+    echo "▷ Adding theo to bashrc..."
+    echo "\nsource ~/.theo/scripts/alias.sh" >> ~/.bashrc
+    echo "▷ Added theo to bashrc."
   else
-    echo "▷ fc-tools already added to bashrc."
+    echo "▷ theo already added to bashrc."
   fi
 fi
 
 if [ -f ~/.zshrc ]; then
-  if ! grep -q "fc-tools" ~/.zshrc; then
-    echo "▷ Adding fc-tools to zshrc..."
+  if ! grep -q "\.theo" ~/.zshrc; then
+    echo "▷ Adding theo to zshrc..."
     echo
-    echo "\nsource ~/.fc-tools/scripts/alias.sh" >> ~/.zshrc
-    echo "▷ Added fc-tools to zshrc."
+    echo "\nsource ~/.theo/scripts/alias.sh" >> ~/.zshrc
+    echo "▷ Added theo to zshrc."
   else
-    echo "▷ fc-tools already added to zshrc."
+    echo "▷ theo already added to zshrc."
   fi
 fi
 
 if [ -f ~/.config/fish/config.fish ]; then
-  if ! grep -q "fc-tools" ~/.config/fish/config.fish; then
-    echo "▷ Adding fc-tools to fish..."
-    echo "\nsource ~/.fc-tools/scripts/alias.fish.sh" >> ~/.config/fish/config.fish
-    echo "▷ Added fc-tools to fish."
+  if ! grep -q "\.theo" ~/.config/fish/config.fish; then
+    echo "▷ Adding theo to fish..."
+    echo "\nsource ~/.theo/scripts/alias.fish.sh" >> ~/.config/fish/config.fish
+    echo "▷ Added theo to fish."
   else
-    echo "▷ fc-tools already added to fish."
+    echo "▷ theo already added to fish."
   fi
 fi
 
-echo "▷ fc-tools installed."
-echo "▷ Restart your terminal to use fc-tools."
-
+echo "▷ theo installed."
+echo "▷ Restart your terminal to use theo."

--- a/src/commands/dependabot/merge.js
+++ b/src/commands/dependabot/merge.js
@@ -206,7 +206,7 @@ async function approvePr (owner, repoName, prNumber) {
     repo: repoName,
     pull_number: prNumber,
     event: 'APPROVE',
-    body: '✅ Auto-approved by fc-tools dependabot merge (low risk)'
+    body: '✅ Auto-approved by theo dependabot merge (low risk)'
   })
 }
 

--- a/src/commands/merge/index.js
+++ b/src/commands/merge/index.js
@@ -109,7 +109,7 @@ class PrMergeCommand {
       console.log()
       console.log(dim('Links:'))
       console.log(`  ${dim('flux:')} https://app.fluxcontrol.com.br/#/fluxo/b23ec9c8-8aeb-471a-8b2f-cd1af4f5e73e?view_mode=table`)
-      console.log(`  ${dim('jobs:')} field merged --from=today --to=today --team=GRID`)
+      console.log(`  ${dim('jobs:')} theo merged --from=today --to=today --team=GRID`)
 
       const everyCardMoved = cards.every(card => card.moved === true)
       if (everyCardMoved) {

--- a/src/commands/repos/index.js
+++ b/src/commands/repos/index.js
@@ -153,7 +153,7 @@ export function formatDelta (current, previous) {
   return chalk.red(` (-${Math.abs(diff)})`)
 }
 
-export const SNAPSHOT_PATH = join(homedir(), '.config', 'fc-tools', 'repos-vulnerabilities.json')
+export const SNAPSHOT_PATH = join(homedir(), '.config', 'theo', 'repos-vulnerabilities.json')
 
 /**
  * Le o snapshot de totais do ultimo run integro.

--- a/src/commands/version/index.js
+++ b/src/commands/version/index.js
@@ -15,8 +15,8 @@ class RebaseCommand {
   }
 
   async action () {
-    const gitDir = `${process.env.HOME}/.fc-tools/.git`
-    const workTree = `${process.env.HOME}/.fc-tools`
+    const gitDir = `${process.env.HOME}/.theo/.git`
+    const workTree = `${process.env.HOME}/.theo`
     const format = '%H%n%an%n%ad%n%s' // hash \n author \n date \n message
 
     const lastCommit = await $(`git --git-dir ${gitDir} --work-tree ${workTree} log -n 1 --format=${format} --date=iso`)

--- a/src/core/check-update.js
+++ b/src/core/check-update.js
@@ -19,7 +19,7 @@ export async function checkUpdate () {
   if (currentSha === latestSha) return
 
   warn('There is a new version available.')
-  warn('Please run \'field-update\' to update.')
+  warn('Please run \'theo-update\' to update.')
 }
 
 async function isUpdateCheckedToday () {

--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ async function createProgram () {
   const packageJSON = await readPackageJSON()
 
   return program
-    .name('field')
+    .name('theo')
     .version(packageJSON.version)
     .description(packageJSON.description)
 }

--- a/test/utils/read-package-json.test.js
+++ b/test/utils/read-package-json.test.js
@@ -6,7 +6,7 @@ import assert from 'node:assert'
 
 test('should read the package.json file and return tests content as a JSON object', async () => {
   const result = await readPackageJSON()
-  assert.equal(result.name, 'fc-tools')
+  assert.equal(result.name, 'theo')
   assert.equal(result.version, '1.0.0')
   assert.equal(result.description, 'Kit com ferramentas e scripts para fluxos de trabalhos de desenvolvedores da field control')
 })


### PR DESCRIPTION
<!-- markdownlint-configure-file
{
  "MD033": false,
  "MD036": false,
  "MD041": false
}
-->

✅ Closes

- Não há issue associada a esta mudança.

✋ publicar antes deste pr

- Nenhum.

⏭️ publicar depois deste pr

- Nenhum. Porém, após o merge é necessário renomear o repositório no GitHub para `LeoFalco/theo` (as URLs do código já apontam para o nome novo e dependem do redirect do GitHub até lá).

**Checklist**

- [ ] Fieldnews - enviar broadcast via e-mail com publicação
- [ ] 🧪 Testes - testes e2e, integrados e unitários foram feitos

<!-- Init:FieldnewsEmailContent -->

**Contexto**

O `fc-tools` é a caixa de ferramentas de linha de comando que usamos no dia a dia de desenvolvimento na Field Control. É ele que automatiza as tarefas repetitivas do nosso fluxo: criar e mergear pull requests, rebasear branches, consultar o que está aberto ou já foi publicado, e conversar com o Flux para mover os cards de estágio.

Na prática, é um programa que se instala uma vez com um comando só e passa a ficar disponível no terminal. Até hoje ele atendia pelo nome `field` — você digitava `field merge`, `field rebase`, e por aí vai.

**Motivações**

O nome `fc-tools` ("FC" de Field Control, "tools" de ferramentas) é um nome descritivo, mas genérico e pouco memorável. Este PR renomeia o projeto para **theo**, dando à ferramenta um nome próprio, mais curto de digitar e mais fácil de referenciar em conversas e documentação.

**Implementação**

A renomeação foi feita em todas as camadas onde o nome antigo aparecia:

| Camada | De | Para |
| --- | --- | --- |
| Nome do pacote | `fc-tools` | `theo` |
| Binário / comando | `field`, `field-update` | `theo`, `theo-update` |
| Diretório de instalação | `~/.fc-tools` | `~/.theo` |
| Diretório de configuração | `~/.config/fc-tools/` | `~/.config/theo/` |
| URLs do repositório | `LeoFalco/fc-tools` | `LeoFalco/theo` |

O ponto que exigiu mais cuidado foi a **migração de quem já tem a ferramenta instalada**. Quem instalou antes tem uma linha `source ~/.fc-tools/scripts/alias.sh` no seu `.bashrc`/`.zshrc`/`config.fish`. Sem tratamento, essa linha continuaria existindo e o comando `field` seguiria funcionando, mas apontando para o clone antigo — duas versões da ferramenta convivendo silenciosamente.

Por isso o `install.sh` ganhou um passo de migração que roda antes da instalação: ele remove as entradas de `~/.fc-tools` dos rc files, sempre gravando um backup `.bak` ao lado. A alternativa avaliada foi apagar o diretório `~/.fc-tools` automaticamente, mas descartamos por ser destrutiva — o script apenas avisa que o diretório antigo pode ser removido manualmente.

Alterações que **não** foram feitas de propósito:

- As chaves `field:` nas configurações de coluna do `chalk-table` (comandos `opened`, `repos`, `merged`, `open`) — são nome de propriedade de dado, não o comando.
- As referências a "Field Control" e `fieldnews` — são o nome da empresa e de um workflow, não o nome da ferramenta.

Sobre a verificação: o lint e a suíte de testes existente (7/7) passam, o `--help` do CLI foi executado e já se identifica como `theo`, e a lógica de migração do `install.sh` foi validada contra rc files de teste — confirmando que ela remove apenas a linha correta, preserva o restante do arquivo, mantém o backup e é idempotente. Não foram escritos testes novos (por isso o item de testes do checklist segue desmarcado): a mudança é de renomeação, e o único teste que tocava o nome — `read-package-json.test.js` — foi atualizado.

**Evoluções**

- Nome próprio, mais curto e memorável, tanto para o projeto quanto para o comando digitado no terminal.
- A migração automática evita o cenário confuso de duas instalações coexistindo, que seria a falha mais provável de uma renomeação feita pela metade.
- Backup `.bak` dos rc files antes de qualquer edição, para que a migração seja reversível.

Ponto de atenção: como o diretório de configuração mudou de caminho, o comando `theo repos` perde o snapshot anterior de vulnerabilidades e mostra o primeiro run sem os deltas de comparação. Nada quebra, e a baseline se refaz sozinha no run seguinte.

**Screenshots**

Por se tratar de uma ferramenta de linha de comando, segue a saída do terminal no lugar de imagens.

<table>
  <thead>
    <tr>
      <th>Antes</th>
      <th>Depois</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>

```console
$ field --help
Usage: field [options] [command]

Kit com ferramentas e scripts para fluxos de
trabalhos de desenvolvedores da field control
```

</td>
      <td>

```console
$ theo --help
Usage: theo [options] [command]

Kit com ferramentas e scripts para fluxos de
trabalhos de desenvolvedores da field control
```

</td>
    </tr>
  </tbody>
</table>

<!-- End:FieldnewsEmailContent -->
