### PR TITLE
fix(repo-clean): protege a branch default quando a base é outra

### DIFF
--- a/src/commands/repo-clean/index.js
+++ b/src/commands/repo-clean/index.js
@@ -1,8 +1,14 @@
 // @ts-check
 
+import chalk from 'chalk'
 import inquirer from 'inquirer'
 import { $ } from '../../core/exec.js'
-import { info } from '../../core/patch-console-log.js'
+import { error, info, warn } from '../../core/patch-console-log.js'
+
+const { bold, cyan, dim, green, red, yellow } = chalk
+
+/** Branches that are never rebased, force-pushed or deleted, on top of the default and base branches. */
+const LEGACY_PROTECTED_BRANCHES = ['homolog', 'preview', 'wiki/master']
 
 class RepoCleanCommand {
   /**
@@ -18,53 +24,92 @@ class RepoCleanCommand {
       .command('clean')
       .description('clean repo branches')
       .option('-b, --base-branch <branch>', 'specify the base branch')
+      .option('-y, --yes', 'skip the confirmation prompt')
       .action(this.action.bind(this))
   }
 
   async action (options) {
+    if (await hasUncommittedChanges()) {
+      error('Working tree sujo — faça commit ou stash antes de rodar repo clean.')
+      process.exitCode = 1
+      return
+    }
+
     const currentBranchName = await $('git rev-parse --abbrev-ref HEAD')
     await $('git fetch --all --prune')
     await $('git remote prune origin')
 
-    const baseBranch = options.baseBranch || await $('git remote show origin').then(result => {
-      const match = result.match(/HEAD branch: (.*)/)
-      return match ? match[1] : 'master'
-    })
+    // A branch default do remote é a de produção: serve de referência, mas nunca é
+    // rebaseada nem deletada. Quando existe `develop`, é ela que agrega o time.
+    const defaultBranch = await resolveDefaultBranch()
+    const baseBranch = options.baseBranch || (await remoteBranchExists('develop') ? 'develop' : defaultBranch)
+
+    const protectedBranches = new Set([defaultBranch, baseBranch, ...LEGACY_PROTECTED_BRANCHES])
 
     const workTrees = await listWorkTrees()
     const workTreeBranches = new Set(workTrees.map((w) => w.branch).filter(Boolean))
     const baseWorkTree = workTrees.find((w) => w.branch === baseBranch)
     const runningFromWorkTree = workTrees.some((w) => w.path === process.cwd() && !w.isMain)
 
-    if (baseWorkTree) {
-      await $(`git pull origin ${baseBranch}`, { cwd: baseWorkTree.path })
-    } else {
-      await $(`git checkout ${baseBranch}`)
-      await $(`git pull origin ${baseBranch}`)
+    await updateDefaultBranch({ defaultBranch, baseBranch, currentBranchName, workTreeBranches })
+
+    const baseUpdate = await updateBaseBranch({ baseBranch, baseWorkTree, currentBranchName })
+    if (!baseUpdate.success) {
+      error(`Não foi possível atualizar ${baseBranch}: ${baseUpdate.stderr || 'conflito no pull --rebase'}. Resolva antes de rodar repo clean.`)
+      process.exitCode = 1
+      return
     }
 
-    const branches = await $('git branch')
-      .then((output) => output.split('\n'))
-      .then((branches) => branches.map((branch) => branch.trim()))
-      .then((branches) => branches.filter((branch) => branch !== ''))
-      .then((branches) => branches.filter((branch) => branch.startsWith('*') === false))
-      .then((branches) => branches.filter((branch) => branch.startsWith('+') === false))
-      .then((branches) => branches.filter((branch) => !workTreeBranches.has(branch)))
-      .then((branches) => branches.filter((branch) => branch !== baseBranch))
-      .then((branches) => branches.filter((branch) => !branch.startsWith(baseBranch)))
-      .then((branches) => branches.filter((branch) => branch !== 'homolog'))
-      .then((branches) => branches.filter((branch) => branch !== 'wiki/master'))
+    const candidates = await listLocalBranches()
+      .then((branches) => branches.filter((branch) => !protectedBranches.has(branch.name)))
+      // Branches presas em outra worktree não podem ser checked out aqui. A worktree
+      // atual é a exceção: sua branch é rebaseada como qualquer outra.
+      .then((branches) => branches.filter((branch) => !workTreeBranches.has(branch.name) || branch.name === currentBranchName))
 
-    const obsoleteBranches = new Set()
-    for (const branch of branches) {
-      if (await hasUnmergedCommits(branch, baseBranch)) {
-        await $(`git checkout ${branch}`)
-        await $(`git rebase ${baseBranch}`)
-        await $(`git push origin ${branch} --force --no-verify`)
-      } else {
-        info(`Branch ${branch} has no unmerged commits relative to ${baseBranch}`)
-        obsoleteBranches.add(branch)
+    const plan = { rebase: [], delete: [] }
+    for (const branch of candidates) {
+      const commits = await countUnmergedCommits(branch.name, baseBranch)
+      if (commits === 0) {
+        plan.delete.push(branch.name)
+        continue
       }
+      plan.rebase.push({ name: branch.name, commits, push: resolvePushMode(branch) })
+    }
+
+    if (plan.rebase.length === 0 && plan.delete.length === 0) {
+      info(`Nenhuma branch local para rebasear ou deletar em relação a ${baseBranch}`)
+    } else {
+      printPlan({ plan, baseBranch, defaultBranch })
+      if (!options.yes && !await confirmPlan()) {
+        info('Cancelado — nada foi alterado.')
+        return
+      }
+    }
+
+    const conflicted = []
+    for (const item of plan.rebase) {
+      const checkout = await $(`git checkout ${item.name}`, { reject: false, returnProperty: 'all' })
+      if (!checkout.success) {
+        warn(`PULADA ${item.name}: não foi possível fazer checkout — branch mantida como estava`)
+        conflicted.push(item.name)
+        continue
+      }
+
+      const rebase = await $(`git rebase ${baseBranch}`, { reject: false, returnProperty: 'all' })
+      if (!rebase.success) {
+        await $('git rebase --abort', { reject: false, returnProperty: 'all' })
+        warn(`PULADA ${item.name}: conflito no rebase sobre ${baseBranch} — rebase abortado, branch mantida como estava`)
+        conflicted.push(item.name)
+        continue
+      }
+
+      if (item.push === 'skip') {
+        info(`${item.name}: rebaseada em ${baseBranch}; push pulado porque a branch remota foi deletada`)
+        continue
+      }
+
+      await $(`git push origin ${item.name} --force --no-verify`)
+      info(`${item.name}: rebaseada em ${baseBranch} e ${item.push === 'create' ? 'branch remota criada' : 'force-push feito'}`)
     }
 
     if (!runningFromWorkTree) {
@@ -73,40 +118,34 @@ class RepoCleanCommand {
 
     const removableWorkTrees = workTrees.filter((w) => !w.isMain && w.path !== process.cwd())
     for (const workTree of removableWorkTrees) {
-      info(`Removing worktree ${workTree.path}${workTree.branch ? ` (${workTree.branch})` : ''}`)
+      info(`Removendo worktree ${workTree.path}${workTree.branch ? ` (${workTree.branch})` : ''}`)
       await $(`git worktree remove ${workTree.path}`)
-      if (workTree.branch) workTreeBranches.delete(workTree.branch)
-    }
-
-    const mergedBranches = await $(`git branch --merged ${baseBranch}`)
-      .then((output) => output.split('\n'))
-      .then((branches) => branches.map((branch) => branch.trim()))
-      .then((branches) => branches.map((branch) => branch.replace('origin/', '')))
-      .then((branches) => branches.filter((branch) => branch !== ''))
-      .then((branches) => branches.filter((branch) => branch.startsWith('*') === false))
-      .then((branches) => branches.filter((branch) => branch.startsWith('+') === false))
-      .then((branches) => branches.filter((branch) => !workTreeBranches.has(branch)))
-      .then((branches) => branches.filter((branch) => branch !== baseBranch))
-      .then((branches) => branches.filter((branch) => branch !== 'preview'))
-      .then((branches) => branches.filter((branch) => branch !== 'homolog'))
-      .then((branches) => branches.filter((branch) => branch.startsWith('master') === false))
-      .then((branches) => branches.filter((branch) => branch !== 'wiki/master'))
-
-    for (const branch of obsoleteBranches) {
-      if (!mergedBranches.includes(branch)) mergedBranches.push(branch)
-    }
-
-    if (mergedBranches.length === 0) {
-      info('No local branches to delete')
-    } else {
-      for (const branch of mergedBranches) {
-        info(`Deleting local branch ${branch}`)
-        await $(`git branch -D ${branch}`)
+      if (!workTree.branch) continue
+      workTreeBranches.delete(workTree.branch)
+      if (protectedBranches.has(workTree.branch)) continue
+      if (await countUnmergedCommits(workTree.branch, baseBranch) === 0) {
+        plan.delete.push(workTree.branch)
+      } else {
+        warn(`${workTree.branch}: estava presa em uma worktree e não foi rebaseada — rode repo clean de novo`)
       }
     }
 
-    if (!mergedBranches.includes(currentBranchName)) {
-      await $(`git checkout ${currentBranchName}`)
+    if (plan.delete.length === 0) {
+      info('Nenhuma branch local para deletar')
+    } else {
+      for (const branch of plan.delete) {
+        info(`Deletando branch local ${branch}`)
+        const deleted = await $(`git branch -D ${branch}`, { reject: false, returnProperty: 'all' })
+        if (!deleted.success) warn(`Não foi possível deletar ${branch}: ${deleted.stderr}`)
+      }
+    }
+
+    if (!plan.delete.includes(currentBranchName)) {
+      await $(`git checkout ${currentBranchName}`, { reject: false, returnProperty: 'all' })
+    }
+
+    if (conflicted.length > 0) {
+      warn(`Branches puladas por conflito ou checkout falho (resolva na mão): ${conflicted.join(', ')}`)
     }
 
     const mergedOnRemoteBranches = await $(`git branch -r --merged origin/${baseBranch}`)
@@ -115,41 +154,218 @@ class RepoCleanCommand {
       .then((branches) => branches.filter((branch) => branch !== ''))
       .then((branches) => branches.map((branch) => branch.replace('origin/', '')))
       .then((branches) => branches.filter((branch) => branch.startsWith('HEAD') === false))
-      .then((branches) => branches.filter((branch) => branch !== baseBranch))
-      .then((branches) => branches.filter((branch) => branch !== 'preview'))
-      .then((branches) => branches.filter((branch) => branch !== 'homolog'))
-      .then((branches) => branches.filter((branch) => branch.startsWith('master') === false))
-      .then((branches) => branches.filter((branch) => branch !== 'wiki/master'))
+      .then((branches) => branches.filter((branch) => !protectedBranches.has(branch)))
 
     if (mergedOnRemoteBranches.length === 0) {
-      info('No remote branches to delete')
-    } else {
-      const { remoteBranchesToDelete } = await inquirer.prompt([{
-        type: 'checkbox',
-        name: 'remoteBranchesToDelete',
-        message: 'Select remote branches to delete',
-        choices: mergedOnRemoteBranches
-      }])
+      info('Nenhuma branch remota para deletar')
+      return
+    }
 
-      for (const branch of remoteBranchesToDelete) {
-        info(`Deleting remote branch ${branch}`)
-        await $(`git push origin --delete ${branch} --no-verify`)
-      }
+    const { remoteBranchesToDelete } = await inquirer.prompt([{
+      type: 'checkbox',
+      name: 'remoteBranchesToDelete',
+      message: 'Selecione as branches remotas para deletar (as suas vêm primeiro)',
+      choices: await buildRemoteBranchChoices(mergedOnRemoteBranches)
+    }])
+
+    const notDeleted = []
+    for (const branch of remoteBranchesToDelete) {
+      info(`Deletando branch remota ${branch}`)
+      const deleted = await $(`git push origin --delete ${branch} --no-verify`, { reject: false, returnProperty: 'all' })
+      if (deleted.success) continue
+
+      // Uma branch sem permissão não pode interromper a fila: as outras seleções continuam.
+      notDeleted.push(branch)
+      warn(`Não foi possível deletar ${branch}: ${summarizePushError(deleted.stderr)}`)
+    }
+
+    if (notDeleted.length > 0) {
+      warn(`Branches remotas não deletadas: ${notDeleted.join(', ')}`)
+      info('No Azure DevOps deletar branch exige a permissão \'Force Push\', concedida só a quem criou a branch. Peça a quem abriu o PR para deletar.')
     }
   }
 }
 
 /**
- * Returns true if `branch` has at least one commit whose patch is not already in `baseBranch`.
- * Uses `git cherry`, which compares by patch-id — so squash-merged commits are correctly identified as merged.
+ * Mostra o autor de cada branch remota e coloca as suas primeiro: no Azure DevOps só dá
+ * para deletar branch que você criou, então escolher às cegas resulta em erro de permissão.
+ * @param {string[]} branches
+ */
+async function buildRemoteBranchChoices (branches) {
+  const me = await $('git config user.email', { disableLog: true, loading: false, reject: false })
+
+  const entries = []
+  for (const branch of branches) {
+    const author = await $(`git log -1 --format=%ae origin/${branch}`, { disableLog: true, loading: false, reject: false })
+    entries.push({ branch, author: typeof author === 'string' ? author : '', mine: Boolean(me) && author === me })
+  }
+
+  entries.sort((a, b) => Number(b.mine) - Number(a.mine) || a.branch.localeCompare(b.branch))
+
+  return entries.map((entry) => ({
+    value: entry.branch,
+    name: entry.mine ? entry.branch : `${entry.branch} ${dim(`(${entry.author})`)}`
+  }))
+}
+
+/** Extrai a linha útil do erro do git push, descartando o resto do ruído. */
+function summarizePushError (stderr) {
+  const lines = (stderr || '').split('\n').map((line) => line.trim()).filter(Boolean)
+  return lines.find((line) => line.includes('[remote rejected]')) || lines[0] || 'erro desconhecido'
+}
+
+/**
+ * Deixa a base em dia antes de calcular o plano: é ela que decide o que já foi mergeado e é
+ * sobre ela que todo mundo é rebaseado. Usa `--rebase` para nunca deixar um merge commit na base.
+ * Se der conflito, aborta o rebase para não deixar a base em estado intermediário.
+ * @returns {Promise<{ success: boolean, stderr?: string }>}
+ */
+async function updateBaseBranch ({ baseBranch, baseWorkTree, currentBranchName }) {
+  const cwd = baseWorkTree ? baseWorkTree.path : undefined
+
+  if (!baseWorkTree) {
+    const checkout = await $(`git checkout ${baseBranch}`, { reject: false, returnProperty: 'all' })
+    if (!checkout.success) return { success: false, stderr: checkout.stderr }
+  }
+
+  const pull = await $(`git pull --rebase origin ${baseBranch}`, { cwd, reject: false, returnProperty: 'all' })
+  if (!pull.success) {
+    await $('git rebase --abort', { cwd, reject: false, returnProperty: 'all' })
+  }
+
+  if (!baseWorkTree) {
+    await $(`git checkout ${currentBranchName}`, { reject: false, returnProperty: 'all' })
+  }
+
+  return pull
+}
+
+/**
+ * Decide o que fazer com o push depois do rebase.
+ * Uma branch cujo upstream sumiu (`gone`) foi deletada no remote de propósito — recriá-la
+ * ressuscitaria uma branch já mergeada, então o push é pulado.
+ * @param {{ name: string, gone: boolean, remoteExists: boolean }} branch
+ * @returns {'skip' | 'create' | 'update'}
+ */
+function resolvePushMode (branch) {
+  if (branch.gone) return 'skip'
+  return branch.remoteExists ? 'update' : 'create'
+}
+
+function printPlan ({ plan, baseBranch, defaultBranch }) {
+  const groups = [
+    { title: 'Rebase + force-push', items: plan.rebase.filter((i) => i.push === 'update'), color: cyan },
+    { title: 'Rebase + push (cria a branch remota)', items: plan.rebase.filter((i) => i.push === 'create'), color: green },
+    { title: 'Rebase local, sem push (branch remota foi deletada)', items: plan.rebase.filter((i) => i.push === 'skip'), color: yellow }
+  ]
+
+  console.log('')
+  console.log(bold(`Plano de limpeza — base: ${baseBranch}`), dim(`(branch de produção protegida: ${defaultBranch})`))
+
+  for (const group of groups) {
+    if (group.items.length === 0) continue
+    console.log('')
+    console.log('  ' + group.color(group.title))
+    for (const item of group.items) {
+      console.log(`    ${item.name} ${dim(`(${item.commits} commit${item.commits === 1 ? '' : 's'} fora de ${baseBranch})`)}`)
+    }
+  }
+
+  if (plan.delete.length > 0) {
+    console.log('')
+    console.log('  ' + red(`Deletar local (nenhum commit fora de ${baseBranch})`))
+    for (const branch of plan.delete) console.log(`    ${branch}`)
+  }
+
+  console.log('')
+}
+
+async function confirmPlan () {
+  const { confirmed } = await inquirer.prompt([{
+    type: 'confirm',
+    name: 'confirmed',
+    message: 'Aplicar esse plano?',
+    default: false
+  }])
+  return confirmed
+}
+
+async function hasUncommittedChanges () {
+  const output = await $('git status --porcelain', { disableLog: true, loading: false })
+  return typeof output === 'string' && output !== ''
+}
+
+/**
+ * Branch default do remote (produção). É só referência — nunca é rebaseada nem deletada.
+ * @returns {Promise<string>}
+ */
+async function resolveDefaultBranch () {
+  const output = await $('git remote show origin', { disableLog: true, loading: false, reject: false })
+  const match = typeof output === 'string' ? output.match(/HEAD branch: (.*)/) : null
+  return match ? match[1].trim() : 'master'
+}
+
+/**
+ * Mantém a branch de produção em dia sem nunca reescrevê-la: só fast-forward.
+ */
+async function updateDefaultBranch ({ defaultBranch, baseBranch, currentBranchName, workTreeBranches }) {
+  if (defaultBranch === baseBranch) return
+  if (!await localBranchExists(defaultBranch)) return
+
+  const result = currentBranchName === defaultBranch
+    ? await $(`git pull --ff-only origin ${defaultBranch}`, { reject: false, returnProperty: 'all' })
+    : workTreeBranches.has(defaultBranch)
+      ? { success: true }
+      : await $(`git fetch origin ${defaultBranch}:${defaultBranch}`, { reject: false, returnProperty: 'all' })
+
+  if (!result.success) {
+    warn(`Não foi possível atualizar ${defaultBranch} por fast-forward — deixando como está`)
+  }
+}
+
+async function localBranchExists (branch) {
+  const result = await $(`git rev-parse --verify --quiet refs/heads/${branch}`, { disableLog: true, loading: false, reject: false, returnProperty: 'all' })
+  return result.success
+}
+
+async function remoteBranchExists (branch) {
+  const result = await $(`git rev-parse --verify --quiet refs/remotes/origin/${branch}`, { disableLog: true, loading: false, reject: false, returnProperty: 'all' })
+  return result.success
+}
+
+/**
+ * Lista as branches locais com o estado do upstream de cada uma.
+ * @returns {Promise<Array<{ name: string, upstream: string | null, gone: boolean, remoteExists: boolean }>>}
+ */
+async function listLocalBranches () {
+  const output = await $('git for-each-ref --format=%(refname:short)%09%(upstream:short)%09%(upstream:track) refs/heads', { disableLog: true, loading: false })
+  if (typeof output !== 'string' || output === '') return []
+
+  const branches = []
+  for (const line of output.split('\n').filter(Boolean)) {
+    const [name, upstream, track] = line.split('\t')
+    branches.push({
+      name,
+      upstream: upstream || null,
+      gone: (track || '').includes('gone'),
+      remoteExists: await remoteBranchExists(name)
+    })
+  }
+  return branches
+}
+
+/**
+ * Conta os commits de `branch` cujo patch ainda não está em `baseBranch`.
+ * Usa `git cherry`, que compara por patch-id — então commits que entraram via squash merge
+ * são corretamente reconhecidos como já mergeados.
  * @param {string} branch
  * @param {string} baseBranch
- * @returns {Promise<boolean>}
+ * @returns {Promise<number>}
  */
-async function hasUnmergedCommits (branch, baseBranch) {
+async function countUnmergedCommits (branch, baseBranch) {
   const output = await $(`git cherry ${baseBranch} ${branch}`, { disableLog: true, loading: false, reject: false })
-  if (typeof output !== 'string') return false
-  return output.split('\n').some((line) => line.startsWith('+'))
+  if (typeof output !== 'string') return 0
+  return output.split('\n').filter((line) => line.startsWith('+')).length
 }
 
 async function listWorkTrees () {


### PR DESCRIPTION
✅ Closes

- Não há issue vinculada

✋ publicar antes deste pr

- Nenhum

⏭️ publicar depois deste pr

- Nenhum

**Checklist**

- [ ] Fieldnews - enviar broadcast via e-mail com publicação
- [ ] 🧪 Testes - testes e2e, integrados e unitários foram feitos

> Testes e2e foram executados manualmente contra um repositório de teste com remote bare (cenários detalhados abaixo), mas **não** foram adicionados testes automatizados neste PR.

<!-- Init:FieldnewsEmailContent -->

**Contexto**

O `theo repo clean` é o comando que faz a faxina das branches do seu repositório local. Ele olha todas as branches que você tem na máquina, rebaseia as que ainda têm trabalho pendente em cima da branch principal, apaga as que já foram mergeadas e oferece a limpeza das branches que sobraram no servidor.

Até então ele partia de um pressuposto: o de que a branch principal do repositório é a mesma branch onde o time integra o trabalho do dia a dia. Nos repositórios que seguem esse modelo isso é verdade — só existe a `master`. Mas há repositórios que separam as duas coisas: a `master` representa o que está em produção e a `develop` é onde as alterações do time se juntam antes de subir. Nesses repositórios o pressuposto quebra.

**Motivações**

Ao rodar o comando em um repositório com esse formato, apontando a base para `develop`, a branch de produção local era **apagada**.

O motivo: existe um filtro que protege a branch default da lista de remoção, mas as branches consideradas obsoletas (aquelas sem nenhum commit fora da base) eram adicionadas à lista *depois* que esse filtro rodava. Como a `master` não tem commits fora da `develop`, ela caía na categoria de obsoleta e passava direto pela guarda, terminando em `git branch -D master`.

Outros problemas apareceram na mesma investigação:

- A branch em que você estava no momento nunca era rebaseada, porque o parsing de `git branch` a descartava junto com o marcador `*`.
- Um conflito em qualquer rebase derrubava o comando inteiro e deixava o repositório em estado de rebase pendente, no meio da fila.
- Branches cuja remota já tinha sido apagada eram **recriadas** no servidor pelo force-push, ressuscitando trabalho já concluído.
- Rebases e force-pushes aconteciam sem qualquer confirmação prévia.
- Na etapa final, uma única falha ao apagar branch remota abortava o comando, e as demais branches selecionadas nem chegavam a ser tentadas.

**Implementação**

O comando foi reorganizado em três etapas explícitas: levantar o estado, montar um plano e só então executá-lo.

*Detecção da base e proteção da branch de produção.* Sem a flag `-b`, o comando agora usa `develop` como base quando ela existe no remote; caso contrário, cai na branch default. A branch default entrou num conjunto de branches protegidas que nunca são rebaseadas, force-pushadas ou deletadas — a injeção das obsoletas agora respeita esse conjunto. Ela continua sendo mantida em dia, mas apenas por fast-forward (`git fetch origin master:master`), o que nunca reescreve histórico.

*Base atualizada antes do plano.* A base é atualizada com `git pull --rebase` antes de qualquer cálculo, já que é ela que define o que já foi mergeado e sobre o que todo mundo será rebaseado. O `--rebase` evita deixar um merge commit na base. Se houver conflito, o rebase é abortado e o comando para com erro, em vez de rebasear todas as branches sobre uma base errada.

*Listagem por `for-each-ref`.* O parsing de `git branch` foi trocado por `git for-each-ref`, que entrega nome, upstream e estado de tracking de uma vez. Isso resolveu a exclusão acidental da branch atual e passou a distinguir os três estados de push que importam.

*Push condicional.* Uma branch cuja remota foi apagada (upstream `gone`) é rebaseada localmente mas **não** é pushada, já que recriá-la ressuscitaria trabalho concluído. Branches com remota existente recebem force-push; branches nunca publicadas têm a remota criada.

*Conflito isolado.* Um conflito de rebase agora executa `git rebase --abort`, registra `PULADA <branch>` no log e segue para a próxima. Ao final, todas as puladas são listadas juntas.

*Plano e confirmação.* Antes de qualquer ação destrutiva, o comando imprime o que pretende fazer, agrupado por tipo de ação, e pede confirmação. A flag `-y` pula a pergunta. Também há uma guarda que impede a execução com working tree sujo.

*Deleção remota resiliente.* Uma falha ao apagar branch remota agora gera apenas um aviso e a fila continua. Como no Azure DevOps apagar branch exige a permissão `Force Push` — concedida somente a quem criou a branch — a seleção passou a exibir o autor das branches de terceiros e a listar as suas primeiro.

**Evoluções**

- Corrige a perda da branch de produção local, que era o problema mais grave.
- O comando deixou de ser tudo-ou-nada: conflitos e erros de permissão isolam a branch afetada em vez de abortar a execução.
- Nenhuma branch remota é recriada sem intenção.
- O plano prévio torna o resultado previsível antes de qualquer force-push.
- O repositório nunca fica em estado de rebase pendente.

**Screenshots**

Por ser um comando de terminal, o antes e depois estão como saída de console.

*Plano exibido antes de qualquer alteração (novo):*

```
Plano de limpeza — base: develop (branch de produção protegida: master)

  Rebase + force-push
    feat/a (1 commit fora de develop)
    feat/d (1 commit fora de develop)

  Rebase + push (cria a branch remota)
    feat/e (1 commit fora de develop)

  Rebase local, sem push (branch remota foi deletada)
    feat/c (1 commit fora de develop)

  Deletar local (nenhum commit fora de develop)
    feat/b

? Aplicar esse plano? (y/N)
```

*Conflito isolado, sem derrubar a execução:*

```
 INFO  feat/a: rebaseada em develop e force-push feito
 INFO  feat/c: rebaseada em develop; push pulado porque a branch remota foi deletada
 WARN  PULADA feat/d: conflito no rebase sobre develop — rebase abortado, branch mantida como estava
 INFO  feat/e: rebaseada em develop e branch remota criada
 WARN  Branches puladas por conflito ou checkout falho (resolva na mão): feat/d
```

*Seleção de branches remotas, agora com autor e as suas primeiro:*

```
? Selecione as branches remotas para deletar (as suas vêm primeiro)
❯◯ feat/b
 ◯ minha/branch
 ◯ dele/branch (gustavo@talkcomm.com.br)
```

*Falha de permissão que antes abortava tudo:*

```
dele/branch  -> FALHOU: ! [remote rejected] dele/branch (pre-receive hook declined)
minha/branch -> DELETADA
feat/b       -> DELETADA
```

**Verificação**

Cenário e2e montado com remote bare cobrindo todos os caminhos, todos confirmados:

| Caso | Esperado | Resultado |
| --- | --- | --- |
| Branch com commit próprio e remota existente | rebase + force-push | hash reescrito, remota atualizada |
| Branch patch-equivalente à base | deletada local | removida |
| Branch com upstream `gone` | rebase local, sem push | rebaseada, remota **não** recriada |
| Branch conflitante | pulada e preservada | commit original intacto, sem rebase pendente |
| Branch local-only | rebase + cria remota | publicada |
| Branch de produção (`master`) | intocada | não rebaseada nem deletada |
| Cancelar na confirmação | nada alterado | branch de origem preservada |
| Delete remoto rejeitado | avisa e continua | demais seleções deletadas |

`npm run lint` e `npm test` passando.

<!-- End:FieldnewsEmailContent -->
