### PR TITLE
feat(pr): adiciona theo pr view com suporte a azure devops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Commands live in `src/commands/<name>/index.js`. Each must export a default obje
 - **`merge`** — Core command. Without `--flux`: merges the current branch's PR using `gh pr merge` with fallback strategies (normal → auto → admin). With `--flux`: fetches cards from the Flux "PUBLISH" stage, shows their PRs with readiness checks, merges them, and moves cards to "MERGED" stage.
 - **`rebase`** — Rebases current branch on the default branch; optionally force-pushes (`-p`).
 - **`pr-create`** — Creates a PR from the current branch. Reads `.github/pull_request_template.md` and `.github/workflows/fieldnews.yml` from the target repo to infer PR title prefixes.
+- **`pr view`** — Shows the pull request of the current branch. Detects the forge from the `origin` url (`src/commands/pr/remote.js`): GitHub is delegated to `gh pr view`, Azure DevOps is queried through `az repos pr list` and rendered locally.
 
 ## Code Style
 
@@ -47,4 +48,4 @@ ESLint with `neostandard` — no semicolons, 2-space indentation, single quotes.
 
 ## External Dependencies
 
-The tool requires `gh` (GitHub CLI) authenticated via `gh auth login` and Git to be available in PATH. The Flux integration uses a hardcoded JWT token in `flux-client.js`.
+The tool requires `gh` (GitHub CLI) authenticated via `gh auth login` and Git to be available in PATH. The Flux integration uses a hardcoded JWT token in `flux-client.js`. Commands that touch Azure DevOps repositories additionally require the Azure CLI (`az`) with the `azure-devops` extension, authenticated via `az login`.

--- a/src/commands/pr/index.js
+++ b/src/commands/pr/index.js
@@ -1,0 +1,26 @@
+// @ts-check
+
+import { viewAction } from './view.js'
+
+class PrCommand {
+  /**
+   * @param {Object} param
+   * @param {import('commander').Command} param.program
+   * */
+  install ({ program }) {
+    const pr = program
+      .command('pr')
+      .description('inspect pull requests of the current repository')
+
+    pr
+      .command('view')
+      .description('show the pull request of the current branch, on GitHub or Azure DevOps')
+      .option('-b, --branch <branch>', 'branch to look up instead of the current one')
+      .option('-w, --web', 'open the pull request in the browser')
+      .option('--json', 'print the raw payload as json')
+      .option('-s, --status <status>', 'azure devops only: active, completed, abandoned or all', 'all')
+      .action(viewAction)
+  }
+}
+
+export default new PrCommand()

--- a/src/commands/pr/remote.js
+++ b/src/commands/pr/remote.js
@@ -1,0 +1,111 @@
+// @ts-check
+
+import { $ } from '../../core/exec.js'
+
+/**
+ * @typedef {Object} RemoteInfo
+ * @property {'github' | 'azure'} provider
+ * @property {string} owner - repository owner on GitHub, organization on Azure DevOps
+ * @property {string} repository
+ * @property {string} [project] - Azure DevOps only
+ * @property {string} [organizationUrl] - Azure DevOps only
+ * @property {string} url - the raw remote url
+ */
+
+// git@ssh.dev.azure.com:v3/{org}/{project}/{repo}
+// ssh://git@ssh.dev.azure.com:22/v3/{org}/{project}/{repo}
+// {org}@vs-ssh.visualstudio.com:v3/{org}/{project}/{repo}
+const AZURE_SSH_PATTERN = /(?:ssh:\/\/)?(?:[^@/]+@)?(?:ssh\.dev\.azure\.com|vs-ssh\.visualstudio\.com)(?::\d+)?[:/]v3\/([^/]+)\/([^/]+)\/(.+?)(?:\.git)?\/?$/
+
+// https://{org}@dev.azure.com/{org}/{project}/_git/{repo}
+const AZURE_HTTPS_PATTERN = /https?:\/\/(?:[^@/]+@)?dev\.azure\.com\/([^/]+)\/(.+)\/_git\/(.+?)(?:\.git)?\/?$/
+
+// https://{org}.visualstudio.com/[DefaultCollection/]{project}/_git/{repo}
+const AZURE_VISUAL_STUDIO_PATTERN = /https?:\/\/(?:[^@/]+@)?([^./]+)\.visualstudio\.com\/(?:DefaultCollection\/)?(.+)\/_git\/(.+?)(?:\.git)?\/?$/
+
+// git@github.com:{owner}/{repo}.git and https://github.com/{owner}/{repo}.git
+const GITHUB_PATTERN = /github\.com[:/]([^/]+)\/(.+?)(?:\.git)?\/?$/
+
+/**
+ * Identifies the forge behind a git remote url.
+ *
+ * @param {string} url
+ * @returns {RemoteInfo | null}
+ */
+export function parseRemoteUrl (url) {
+  const remoteUrl = (url || '').trim()
+
+  if (!remoteUrl) return null
+
+  const azureMatch = remoteUrl.match(AZURE_SSH_PATTERN)
+    || remoteUrl.match(AZURE_HTTPS_PATTERN)
+    || remoteUrl.match(AZURE_VISUAL_STUDIO_PATTERN)
+
+  if (azureMatch) {
+    const [, organization, project, repository] = azureMatch
+
+    return {
+      provider: 'azure',
+      owner: decode(organization),
+      project: decode(project),
+      repository: decode(repository),
+      organizationUrl: `https://dev.azure.com/${organization}`,
+      url: remoteUrl
+    }
+  }
+
+  const githubMatch = remoteUrl.match(GITHUB_PATTERN)
+
+  if (githubMatch) {
+    const [, owner, repository] = githubMatch
+
+    return {
+      provider: 'github',
+      owner: decode(owner),
+      repository: decode(repository),
+      url: remoteUrl
+    }
+  }
+
+  return null
+}
+
+/**
+ * Reads the remote url of the current repository and identifies its forge.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.remote] - remote name (default: origin)
+ * @returns {Promise<RemoteInfo | null>}
+ */
+export async function getRemoteInfo (options) {
+  const remote = options?.remote || 'origin'
+
+  const url = await $(`git remote get-url ${remote}`, { loading: false, disableLog: true })
+    .then(result => result?.toString() || '')
+    .catch(() => '')
+
+  return parseRemoteUrl(url)
+}
+
+/**
+ * Builds the browser url of an Azure DevOps pull request.
+ *
+ * @param {RemoteInfo} remoteInfo
+ * @param {number} pullRequestId
+ * @returns {string}
+ */
+export function buildAzurePullRequestUrl (remoteInfo, pullRequestId) {
+  const organization = encodeURIComponent(remoteInfo.owner)
+  const project = encodeURIComponent(remoteInfo.project || '')
+  const repository = encodeURIComponent(remoteInfo.repository)
+
+  return `https://dev.azure.com/${organization}/${project}/_git/${repository}/pullrequest/${pullRequestId}`
+}
+
+function decode (value) {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}

--- a/src/commands/pr/view.js
+++ b/src/commands/pr/view.js
@@ -1,0 +1,212 @@
+// @ts-check
+
+import chalk from 'chalk'
+import { format } from 'date-fns'
+import open from 'open'
+import { $ } from '../../core/exec.js'
+import { error, info, warn } from '../../core/patch-console-log.js'
+import { buildAzurePullRequestUrl, getRemoteInfo } from './remote.js'
+
+const { bold, cyan, dim, green, red, yellow } = chalk
+
+const GITHUB_JSON_FIELDS = 'number,title,state,isDraft,author,headRefName,baseRefName,mergeable,reviewDecision,url'
+
+const AZURE_VOTE_LABELS = {
+  '10': green('approved'),
+  '5': green('approved with suggestions'),
+  '0': dim('no vote'),
+  '-5': yellow('waiting for author'),
+  '-10': red('rejected')
+}
+
+const AZURE_STATUS_LABELS = {
+  active: green('active'),
+  completed: cyan('completed'),
+  abandoned: dim('abandoned')
+}
+
+/**
+ * @param {Object} options
+ * @param {string | undefined} options.branch
+ * @param {boolean | undefined} options.web
+ * @param {boolean | undefined} options.json
+ * @param {string} options.status
+ */
+export async function viewAction (options) {
+  const remoteInfo = await getRemoteInfo()
+
+  if (!remoteInfo) {
+    error('could not identify the forge of remote "origin", expected a GitHub or Azure DevOps url')
+    process.exit(1)
+  }
+
+  const branch = options.branch || await $('git rev-parse --abbrev-ref HEAD', { loading: false, disableLog: true })
+    .then(result => result?.toString() || '')
+
+  if (!branch || branch === 'HEAD') {
+    error('could not resolve the current branch, use --branch to inform it')
+    process.exit(1)
+  }
+
+  if (remoteInfo.provider === 'azure') {
+    await viewAzurePullRequest({ remoteInfo, branch: String(branch), options })
+    return
+  }
+
+  await viewGithubPullRequest({ branch: String(branch), options })
+}
+
+/**
+ * Delegates to the GitHub CLI, which already knows how to render a pull request.
+ */
+async function viewGithubPullRequest ({ branch, options }) {
+  const commandParts = ['gh', 'pr', 'view', escapeArgument(branch)]
+
+  if (options.web) commandParts.push('--web')
+  if (options.json) commandParts.push('--json', GITHUB_JSON_FIELDS)
+
+  const result = await $(commandParts.join(' '), {
+    stdio: 'inherit',
+    loading: false,
+    disableLog: true,
+    reject: false,
+    returnProperty: 'all'
+  }).catch(() => ({ success: false }))
+
+  if (!result.success) process.exitCode = 1
+}
+
+async function viewAzurePullRequest ({ remoteInfo, branch, options }) {
+  const command = [
+    'az repos pr list',
+    `--org ${remoteInfo.organizationUrl}`,
+    `--project ${escapeArgument(remoteInfo.project)}`,
+    `--repository ${escapeArgument(remoteInfo.repository)}`,
+    `--source-branch ${escapeArgument(branch)}`,
+    `--status ${escapeArgument(options.status)}`,
+    '--output json'
+  ].join(' ')
+
+  const pullRequests = await runAzureCommand(command)
+
+  if (!pullRequests.length) {
+    warn(`no pull request found for branch '${branch}' in ${remoteInfo.project}/${remoteInfo.repository}`)
+    process.exitCode = 1
+    return
+  }
+
+  // active pull requests first, then the most recent ones
+  pullRequests.sort((left, right) => {
+    return statusRank(left) - statusRank(right) || right.pullRequestId - left.pullRequestId
+  })
+
+  if (options.json) {
+    console.log(JSON.stringify(pullRequests, null, 2))
+    return
+  }
+
+  if (options.web) {
+    const url = buildAzurePullRequestUrl(remoteInfo, pullRequests[0].pullRequestId)
+    info(`opening ${url}`)
+    await open(url)
+    return
+  }
+
+  for (const pullRequest of pullRequests) {
+    printAzurePullRequest({ pullRequest, remoteInfo })
+  }
+}
+
+function printAzurePullRequest ({ pullRequest, remoteInfo }) {
+  const status = AZURE_STATUS_LABELS[pullRequest.status] || pullRequest.status
+  const draft = pullRequest.isDraft ? yellow(' draft') : ''
+
+  console.log('')
+  console.log(`${bold(`#${pullRequest.pullRequestId}`)} ${status}${draft} ${bold(pullRequest.title)}`)
+
+  printField('branch', `${shortRefName(pullRequest.sourceRefName)} -> ${shortRefName(pullRequest.targetRefName)}`)
+  printField('author', pullRequest.createdBy?.displayName)
+  printField('created', formatDate(pullRequest.creationDate))
+  printField('merge', pullRequest.mergeFailureMessage || pullRequest.mergeStatus)
+  printField('auto complete', pullRequest.autoCompleteSetBy?.displayName
+    ? `set by ${pullRequest.autoCompleteSetBy.displayName}`
+    : dim('off'))
+  printField('reviewers', formatReviewers(pullRequest.reviewers))
+  printField('url', cyan(buildAzurePullRequestUrl(remoteInfo, pullRequest.pullRequestId)))
+}
+
+function printField (label, value) {
+  if (!value) return
+  console.log(`  ${dim(label.padEnd(14))}${value}`)
+}
+
+function formatReviewers (reviewers) {
+  if (!reviewers?.length) return dim('none')
+
+  return reviewers
+    .map(reviewer => {
+      const vote = AZURE_VOTE_LABELS[String(reviewer.vote)] ?? reviewer.vote
+      const required = reviewer.isRequired ? ' *' : ''
+      return `${reviewer.displayName}${required} (${vote})`
+    })
+    .join(', ')
+}
+
+async function runAzureCommand (command) {
+  const result = await $(command, {
+    loading: false,
+    disableLog: true,
+    reject: false,
+    returnProperty: 'all'
+  }).catch(err => ({ success: false, stdout: '', stderr: err.shortMessage || err.message }))
+
+  if (!result.success) {
+    error('failed to query Azure DevOps')
+    if (result.stderr) error(result.stderr)
+    printAzureHint(result.stderr)
+    process.exit(1)
+  }
+
+  return JSON.parse(result.stdout || '[]')
+}
+
+function printAzureHint (stderr) {
+  const message = String(stderr || '')
+
+  if (message.includes('ENOENT') || message.includes('command not found')) {
+    info('install the Azure CLI: brew install azure-cli')
+    return
+  }
+
+  if (message.includes('not in the') && message.includes('extension')) {
+    info('install the devops extension: az extension add --name azure-devops')
+    return
+  }
+
+  if (message.includes('az login') || message.includes('Unauthorized') || message.includes('TF400813')) {
+    info('authenticate first: az login')
+  }
+}
+
+function statusRank (pullRequest) {
+  return pullRequest.status === 'active' ? 0 : 1
+}
+
+function shortRefName (refName) {
+  return String(refName || '').replace(/^refs\/heads\//, '')
+}
+
+function formatDate (value) {
+  if (!value) return null
+
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) return null
+
+  return format(date, 'dd/MM/yyyy HH:mm')
+}
+
+// execa splits the command on whitespace, so spaces need escaping
+function escapeArgument (value) {
+  return String(value ?? '').replaceAll(' ', '\\ ')
+}

--- a/test/commands/pr/remote.test.js
+++ b/test/commands/pr/remote.test.js
@@ -1,0 +1,61 @@
+// @ts-check
+
+import assert from 'node:assert'
+import test from 'node:test'
+import { buildAzurePullRequestUrl, parseRemoteUrl } from '../../../src/commands/pr/remote.js'
+
+test('should identify an azure devops ssh remote', () => {
+  const result = parseRemoteUrl('git@ssh.dev.azure.com:v3/talkcomunication/Projetos/EpbxManagerNet9')
+
+  assert.equal(result?.provider, 'azure')
+  assert.equal(result?.owner, 'talkcomunication')
+  assert.equal(result?.project, 'Projetos')
+  assert.equal(result?.repository, 'EpbxManagerNet9')
+  assert.equal(result?.organizationUrl, 'https://dev.azure.com/talkcomunication')
+})
+
+test('should identify an azure devops https remote', () => {
+  const result = parseRemoteUrl('https://talkcomunication@dev.azure.com/talkcomunication/Projetos/_git/EpbxManagerNet9')
+
+  assert.equal(result?.provider, 'azure')
+  assert.equal(result?.owner, 'talkcomunication')
+  assert.equal(result?.project, 'Projetos')
+  assert.equal(result?.repository, 'EpbxManagerNet9')
+})
+
+test('should identify a legacy visualstudio.com remote and decode the project name', () => {
+  const result = parseRemoteUrl('https://contoso.visualstudio.com/DefaultCollection/My%20Project/_git/MyRepo')
+
+  assert.equal(result?.provider, 'azure')
+  assert.equal(result?.owner, 'contoso')
+  assert.equal(result?.project, 'My Project')
+  assert.equal(result?.repository, 'MyRepo')
+})
+
+test('should identify github remotes', () => {
+  const ssh = parseRemoteUrl('git@github.com:LeoFalco/theo.git')
+
+  assert.equal(ssh?.provider, 'github')
+  assert.equal(ssh?.owner, 'LeoFalco')
+  assert.equal(ssh?.repository, 'theo')
+
+  const https = parseRemoteUrl('https://github.com/LeoFalco/theo.git')
+
+  assert.equal(https?.provider, 'github')
+  assert.equal(https?.owner, 'LeoFalco')
+  assert.equal(https?.repository, 'theo')
+})
+
+test('should return null for unknown remotes', () => {
+  assert.equal(parseRemoteUrl('git@gitlab.com:group/project.git'), null)
+  assert.equal(parseRemoteUrl(''), null)
+})
+
+test('should build the azure pull request browser url', () => {
+  const remoteInfo = parseRemoteUrl('git@ssh.dev.azure.com:v3/talkcomunication/Projetos/EpbxManagerNet9')
+
+  assert.equal(
+    buildAzurePullRequestUrl(/** @type {any} */(remoteInfo), 6039),
+    'https://dev.azure.com/talkcomunication/Projetos/_git/EpbxManagerNet9/pullrequest/6039'
+  )
+})


### PR DESCRIPTION
✅ Closes

- Não há issue vinculada

✋ publicar antes deste pr

- Nenhum

⏭️ publicar depois deste pr

- Nenhum

**Checklist**

- [ ] Fieldnews - enviar broadcast via e-mail com publicação
- [ ] 🧪 Testes - testes e2e, integrados e unitários foram feitos

> Testes unitários automatizados foram adicionados para o parser de remote (`test/commands/pr/remote.test.js`, 6 casos). Os dois caminhos do comando foram validados manualmente contra repositórios reais, mas **não** há testes automatizados cobrindo a execução do `az` e do `gh`.

<!-- Init:FieldnewsEmailContent -->

**Contexto**

O `theo` é a caixa de ferramentas de linha de comando que usamos no dia a dia de desenvolvimento. Boa parte do que ele automatiza gira em torno de pull requests: criar, rebasear, mergear, listar o que está aberto.

Todo esse ferramental nasceu apoiado no `gh`, a CLI oficial do GitHub. Faz sentido, porque é lá que a maioria dos nossos repositórios vive. Só que nem todos: alguns projetos ficam hospedados no Azure DevOps, que é a plataforma da Microsoft para o mesmo tipo de trabalho — guardar código, revisar alterações, rodar as esteiras de publicação. São dois serviços que fazem a mesma coisa, mas cada um com o seu próprio jeito de ser consultado.

**Motivações**

Para ver o pull request da branch em que você está, o caminho no GitHub é curto: `gh pr view` e pronto. No Azure DevOps não existe esse atalho. O equivalente é montar a mão um comando com quatro parâmetros que só repetem informação que o próprio repositório já sabe:

```sh
az repos pr list \
  --org https://dev.azure.com/talkcomunication \
  --project Projetos \
  --repository EpbxManagerNet9 \
  --source-branch $(git branch --show-current) \
  --status all -o table
```

Organização, projeto e repositório estão todos escritos na url do remote. Digitar isso de novo a cada consulta, trocando os valores conforme o repositório, é trabalho que a ferramenta deveria fazer. E a saída padrão em tabela ainda esconde o que mais importa: para onde a branch aponta, se o merge está limpo, quem já revisou.

O resultado prático é que quem trabalha nos dois mundos precisa lembrar de qual comando usar em qual pasta.

**Implementação**

Novo grupo de comandos `pr`, começando pelo subcomando `view`:

```sh
theo pr view                    # pull request da branch atual
theo pr view -b outra/branch    # de outra branch
theo pr view -w                 # abre no navegador
theo pr view --json             # payload cru
theo pr view -s active          # só Azure: active | completed | abandoned | all (padrão)
```

O comando não pergunta nada e não depende de configuração. Ele lê `git remote get-url origin` e identifica a plataforma pela própria url, cobrindo os formatos ssh e https de cada uma, inclusive o legado `visualstudio.com`:

| Remote | Plataforma | Extraído |
| --- | --- | --- |
| `git@ssh.dev.azure.com:v3/{org}/{proj}/{repo}` | Azure DevOps | organização, projeto, repositório |
| `https://{org}@dev.azure.com/{org}/{proj}/_git/{repo}` | Azure DevOps | organização, projeto, repositório |
| `https://{org}.visualstudio.com/{proj}/_git/{repo}` | Azure DevOps | organização, projeto, repositório |
| `git@github.com:{owner}/{repo}.git` | GitHub | dono, repositório |

A partir daí o caminho se divide:

- **GitHub** — delega para `gh pr view`, repassando `--web` e `--json`. Não faz sentido reescrever uma renderização que já existe e é boa.
- **Azure DevOps** — monta o `az repos pr list` com os dados tirados da url, recebe o json e formata a saída aqui.

Quando o remote não é de nenhuma das duas, o comando avisa e sai com erro em vez de tentar adivinhar.

A separação ficou em três arquivos: `remote.js` guarda só o reconhecimento da url (função pura, é o que os testes cobrem), `view.js` tem a ação e a formatação, e `index.js` registra o grupo no Commander. O grupo `pr` nasce aberto para receber outros subcomandos depois.

Duas decisões que valem registro:

- Os pull requests vêm ordenados com os ativos primeiro e, dentro disso, do mais recente para o mais antigo. Como o padrão é `--status all`, uma branch reaproveitada pode ter mais de um pull request, e o que interessa é o que está em aberto.
- Falha do `az` vira instrução, não despejo de stack. CLI ausente sugere `brew install azure-cli`, extensão faltando sugere `az extension add --name azure-devops`, sessão expirada sugere `az login`.

**Evoluções**

O mesmo comando passa a funcionar nos dois tipos de repositório, sem que você precise lembrar em qual está. Some a necessidade de decorar organização e projeto, e some o risco de consultar o repositório errado por ter copiado o comando de outra pasta.

A saída do Azure DevOps agora mostra numa olhada o que antes exigia abrir o navegador: destino da branch, autor, situação do merge, voto de cada revisor e se o auto complete está ligado. O `-w` abre direto o pull request quando você realmente precisa da tela.

Para automação, `--json` devolve o payload cru dos dois lados, e o comando sai com código 1 quando não encontra pull request — mesmo comportamento do `gh`, então dá para encadear em script.

Por fim, o reconhecimento de remote ficou isolado e testado. Qualquer comando futuro do `theo` que precise saber onde o repositório está hospedado importa `getRemoteInfo()` e pronto.

**Screenshots**

*Pull request encontrado em repositório do Azure DevOps:*

```
#6039 active docs(skill): destaca o limite de 4000 caracteres da descrição do PR
  branch        docs/skill-pr-limite-descricao -> develop
  author        Leonardo Falco
  created       07/08/2026 20:17
  merge         succeeded
  auto complete off
  reviewers     none
  url           https://dev.azure.com/talkcomunication/Projetos/_git/EpbxManagerNet9/pullrequest/6039
```

*Branch sem pull request:*

```
 WARN  no pull request found for branch 'chore/skill-grilling-prompts-nativos' in Projetos/EpbxManagerNet9
```

*Ajuda do subcomando:*

```
Usage: theo pr view [options]

show the pull request of the current branch, on GitHub or Azure DevOps

Options:
  -b, --branch <branch>  branch to look up instead of the current one
  -w, --web              open the pull request in the browser
  --json                 print the raw payload as json
  -s, --status <status>  azure devops only: active, completed, abandoned or all
                         (default: "all")
  -h, --help             display help for command
```

**Verificação**

| Caso | Esperado | Resultado |
| --- | --- | --- |
| Remote Azure ssh, branch com pull request aberto | detalhes do pull request | renderizado, url correta |
| Remote Azure ssh, branch sem pull request | aviso e saída 1 | confirmado |
| Remote Azure com `--json` | payload cru do `az` | confirmado |
| Remote GitHub | delega para `gh pr view` | confirmado (mensagem do próprio `gh`) |
| Remote não reconhecido | erro explicativo | coberto por teste unitário |
| Url do Azure com projeto contendo espaço | projeto decodificado | coberto por teste unitário |

Ressalva honesta: o caminho do GitHub foi exercitado apenas com uma branch **sem** pull request aberto, então a delegação para o `gh` está confirmada, mas a renderização de um pull request real do GitHub não foi vista rodando.

`npm run lint` e `npm test` (13 testes) passando.

<!-- End:FieldnewsEmailContent -->
