### PR TITLE
refactor(core): parametriza a org do github via variavel de ambiente

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,5 @@
 GOOGLE_CHAT_WEBHOOK_URL=https://chat.googleapis.com/v1/spaces/SPACE_ID/messages?key=API_KEY&token=TOKEN
+
+# Organização do GitHub consultada pelos comandos (repos, opened, merged, merge).
+# Padrão: FieldControl
+GITHUB_ORG=FieldControl

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Commands live in `src/commands/<name>/index.js`. Each must export a default obje
 - **`src/core/exec.js`** — The `$()` helper wraps `execa` for running shell commands. Key options: `json: true` parses stdout as JSON, `returnProperty: 'all'` returns `{ exitCode, success, stdout, stderr }`, `reject: false` prevents throwing on non-zero exit, `loading: false` suppresses the spinner.
 - **`src/core/githubFacade.js`** — Octokit-based GitHub GraphQL + REST client. Handles PR queries (with checks, reviews, labels), branch comparison, and PR updates (rebase/update branch).
 - **`src/core/constants.js`** — Team member lists organized by team (CMMS, FSM, QUALITY). Adding/removing members here affects all commands that filter by team.
+- **`src/core/env.js`** — Loads the repo-root `.env` (via dotenv) and exports config read from it. `GITHUB_ORG` is the GitHub organization queried by `repos`, `opened` and `merged` (defaults to `FieldControl`). See `.env.example`.
 - **`src/core/patch-console-log.js`** — Provides `error`, `info`, `warn` helpers with colored prefixes.
 
 ### Services

--- a/src/commands/repos/index.js
+++ b/src/commands/repos/index.js
@@ -3,11 +3,12 @@
 import chalk from 'chalk'
 import chalkTable from 'chalk-table'
 import { $ } from '../../core/exec.js'
+import { GITHUB_ORG } from '../../core/env.js'
 import { readFile, writeFile, mkdir } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 
-const ORG = 'FieldControl'
+const ORG = GITHUB_ORG
 const ADMIN = 'admin'
 
 // Severidades do Dependabot da mais grave para a menos grave.
@@ -27,7 +28,7 @@ class ReposCommand {
   install ({ program }) {
     program
       .command('repos')
-      .description('list fieldcontrol repositories you can merge into')
+      .description(`list ${ORG} repositories you can merge into`)
       .action(this.action.bind(this))
   }
 

--- a/src/core/env.js
+++ b/src/core/env.js
@@ -1,0 +1,15 @@
+// @ts-check
+
+import dotEnv from 'dotenv'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+dotEnv.config({
+  path: join(dirname(fileURLToPath(import.meta.url)), '../../.env'),
+  debug: false,
+  quiet: true
+})
+
+// Organização do GitHub usada nas consultas de PRs, checks e repositórios.
+// Configurável via .env para permitir o uso do theo fora da FieldControl.
+export const GITHUB_ORG = process.env.GITHUB_ORG || 'FieldControl'

--- a/src/core/githubFacade.js
+++ b/src/core/githubFacade.js
@@ -211,7 +211,7 @@ class GithubFacade {
       return Promise.all(
         pulls.map(async (pull) => {
           Object.assign(pull, {
-            checks: pull.headRef ? await getChecks('FieldControl', pull.repository.name, pull.headRef.target.oid) : []
+            checks: pull.headRef ? await getChecks(params.organization, pull.repository.name, pull.headRef.target.oid) : []
           })
           console.log(`check consultado ${pull.url} (${--pending} restantes)`)
           return pull
@@ -228,7 +228,7 @@ class GithubFacade {
     }).then((response) => {
       return response.viewer.organization.repository.pullRequest
     }).then(async (pull) => {
-      pull.checks = pull.headRef ? await getChecks('FieldControl', pull.repository.name, pull.headRef.target.oid) : []
+      pull.checks = pull.headRef ? await getChecks(params.organization, pull.repository.name, pull.headRef.target.oid) : []
       return pull
     })
   }

--- a/src/core/octokit.js
+++ b/src/core/octokit.js
@@ -1,14 +1,6 @@
-import dotEnv from 'dotenv'
 import { execSync } from 'node:child_process'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { Octokit } from 'octokit'
-
-dotEnv.config({
-  path: join(dirname(fileURLToPath(import.meta.url)), '../../.env'),
-  debug: false,
-  quiet: true
-})
+import './env.js'
 
 function getToken () {
   if (process.env.GH_TOKEN) return process.env.GH_TOKEN

--- a/src/modules/merged-data.js
+++ b/src/modules/merged-data.js
@@ -3,6 +3,7 @@
 import { differenceInBusinessDays, format, parseISO } from 'date-fns'
 import { toZonedTime } from 'date-fns-tz'
 import { TEAMS } from '../core/constants.js'
+import { GITHUB_ORG } from '../core/env.js'
 import { githubFacade } from '../core/githubFacade.js'
 import { getTeamByAssignee } from '../utils/utils.js'
 
@@ -12,7 +13,7 @@ export async function fetchMergedPRs (team, from, to) {
   const pulls = await githubFacade.listPullRequestsV2({
     assignees,
     state: 'MERGED',
-    organization: 'FieldControl',
+    organization: GITHUB_ORG,
     from,
     to
   }).then((pulls) => {

--- a/src/modules/opened-data.js
+++ b/src/modules/opened-data.js
@@ -2,6 +2,7 @@
 
 import { format } from 'date-fns'
 import { QUALITY_TEAM, TEAMS } from '../core/constants.js'
+import { GITHUB_ORG } from '../core/env.js'
 import { githubFacade } from '../core/githubFacade.js'
 import { calcAge, hasPublishLabel, isApproved, isChecksPassed, isChecksInProgress, isMergeable, isNotFreelance, isNotWait, isQualityOk, isReady, isRejected } from '../utils/utils.js'
 
@@ -16,7 +17,7 @@ export async function fetchOpenedPRs (team) {
 
   const pulls = await githubFacade.listPullRequestsV2({
     assignees,
-    organization: 'FieldControl',
+    organization: GITHUB_ORG,
     state: 'OPEN',
     from,
     to


### PR DESCRIPTION
✅ Closes

- #closes numero_ou_link_da_issue

✋ publicar antes deste pr

- #numero_ou_link_do_pr

⏭️ publicar depois deste pr

- #numero_ou_link_do_pr

**Checklist**

- [ ] Fieldnews - enviar broadcast via e-mail com publicação
- [ ] 🧪 Testes - testes e2e, integrados e unitários foram feitos

<!-- Init:FieldnewsEmailContent -->

**Contexto**

O `theo` é o kit de comandos que a gente usa no dia a dia para listar repositórios, acompanhar pull requests abertos e mergeados e fazer merge das cartas do Flux. Vários desses comandos precisam saber em qual organização do GitHub procurar — e até agora esse nome estava escrito direto no código, em cinco lugares diferentes.

**Motivações**

Com a organização fixa no código, não dá para usar o `theo` em outra org sem editar os fontes, e qualquer troca futura exigiria caçar as ocorrências espalhadas. Além disso, o `githubFacade` sempre buscava os checks na org fixa, mesmo quando o chamador passava um dono diferente — no `merge --flux` o dono vem da carta do Flux (`pr.owner`), então um PR de fora da org resultaria em consulta de checks na org errada.

**Implementação**

- Novo `src/core/env.js`: centraliza o carregamento do `.env` (via dotenv) e exporta `GITHUB_ORG`, com valor padrão `FieldControl` para não mudar o comportamento de quem não tem `.env`.
- `src/core/octokit.js` passa a importar `./env.js` em vez de repetir o `dotenv.config()`.
- `src/commands/repos/index.js`, `src/modules/opened-data.js` e `src/modules/merged-data.js` passam a ler a org de `GITHUB_ORG`. A descrição do `theo repos` no `--help` agora interpola o nome da org em vez do texto fixo.
- `src/core/githubFacade.js` passa a usar o `params.organization` que já recebia nas duas chamadas de `getChecks`, em vez do nome fixo.
- `.env.example` e `CLAUDE.md` documentam a variável.

**Evoluções**

- A organização vira configuração: basta `GITHUB_ORG=MinhaOrg` no `.env`.
- Um só ponto de carregamento do `.env`, em vez de espalhar `dotenv.config()` por módulo.
- Corrige a busca de checks na org errada quando o PR não pertence à org padrão.

**Screenshots**

Sem alteração visual — a única mudança perceptível é o texto do `theo repos --help`, que passa a citar a org configurada.

<!-- End:FieldnewsEmailContent -->
