### PR TITLE
refactor(core): remove mencoes a FieldControl do codigo e da documentacao

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 GOOGLE_CHAT_WEBHOOK_URL=https://chat.googleapis.com/v1/spaces/SPACE_ID/messages?key=API_KEY&token=TOKEN
 
 # Organização do GitHub consultada pelos comandos (repos, opened, merged, merge).
-# Padrão: FieldControl
-GITHUB_ORG=FieldControl
+# Obrigatório, não possui valor padrão.
+GITHUB_ORG=my-github-org

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`theo` is an ESM Node.js CLI toolkit (`theo` binary) for Field Control developer workflows. It automates Git operations, GitHub PR management, and integration with the Flux project management tool.
+`theo` is an ESM Node.js CLI toolkit (`theo` binary) for developer workflows. It automates Git operations, GitHub PR management, and integration with the Flux project management tool.
 
 ## Commands
 
@@ -28,7 +28,7 @@ Commands live in `src/commands/<name>/index.js`. Each must export a default obje
 - **`src/core/exec.js`** — The `$()` helper wraps `execa` for running shell commands. Key options: `json: true` parses stdout as JSON, `returnProperty: 'all'` returns `{ exitCode, success, stdout, stderr }`, `reject: false` prevents throwing on non-zero exit, `loading: false` suppresses the spinner.
 - **`src/core/githubFacade.js`** — Octokit-based GitHub GraphQL + REST client. Handles PR queries (with checks, reviews, labels), branch comparison, and PR updates (rebase/update branch).
 - **`src/core/constants.js`** — Team member lists organized by team (CMMS, FSM, QUALITY). Adding/removing members here affects all commands that filter by team.
-- **`src/core/env.js`** — Loads the repo-root `.env` (via dotenv) and exports config read from it. `GITHUB_ORG` is the GitHub organization queried by `repos`, `opened` and `merged` (defaults to `FieldControl`). See `.env.example`.
+- **`src/core/env.js`** — Loads the repo-root `.env` (via dotenv) and exports config read from it. `GITHUB_ORG` is the GitHub organization queried by `repos`, `opened` and `merged`; it has no default, so use `requireGithubOrg()` at call sites to fail with an actionable message when it is unset. See `.env.example`.
 - **`src/core/patch-console-log.js`** — Provides `error`, `info`, `warn` helpers with colored prefixes.
 
 ### Services

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Theo
 
-Kit com ferramentas e scripts para fluxos de trabalhos de desenvolvedores da field control
+Kit com ferramentas e scripts para fluxos de trabalho de desenvolvedores
 
 ## Instalação
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "theo",
   "version": "1.0.0",
-  "description": "Kit com ferramentas e scripts para fluxos de trabalhos de desenvolvedores da field control",
+  "description": "Kit com ferramentas e scripts para fluxos de trabalho de desenvolvedores",
   "main": "src/index.js",
   "type": "module",
   "bin": {
@@ -22,7 +22,8 @@
   "keywords": [
     "cli",
     "scripts",
-    "field-control"
+    "git",
+    "github"
   ],
   "author": "leonardo.falco@outlook.com",
   "license": "MIT",

--- a/src/commands/repos/index.js
+++ b/src/commands/repos/index.js
@@ -3,12 +3,11 @@
 import chalk from 'chalk'
 import chalkTable from 'chalk-table'
 import { $ } from '../../core/exec.js'
-import { GITHUB_ORG } from '../../core/env.js'
+import { requireGithubOrg } from '../../core/env.js'
 import { readFile, writeFile, mkdir } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 
-const ORG = GITHUB_ORG
 const ADMIN = 'admin'
 
 // Severidades do Dependabot da mais grave para a menos grave.
@@ -28,7 +27,7 @@ class ReposCommand {
   install ({ program }) {
     program
       .command('repos')
-      .description(`list ${ORG} repositories you can merge into`)
+      .description('list organization repositories you can merge into')
       .action(this.action.bind(this))
   }
 
@@ -36,7 +35,7 @@ class ReposCommand {
     const mergeableRepos = await fetchMergeableRepos()
 
     if (mergeableRepos.length === 0) {
-      console.log(chalk.yellow(`Nenhum repositório da org ${ORG} com permissão de merge`))
+      console.log(chalk.yellow(`Nenhum repositório da org ${requireGithubOrg()} com permissão de merge`))
       return
     }
 
@@ -86,6 +85,8 @@ function printSummary (totals, previous) {
  * @returns {Promise<Array<{ repo: string, permission: string }>>}
  */
 async function fetchMergeableRepos () {
+  const org = requireGithubOrg()
+
   const repos = await $('gh api --paginate /user/repos?affiliation=organization_member', {
     json: true,
     loading: false
@@ -93,7 +94,7 @@ async function fetchMergeableRepos () {
 
   return (repos || [])
     // @ts-ignore
-    .filter((repo) => repo.owner?.login?.toLowerCase() === ORG.toLowerCase())
+    .filter((repo) => repo.owner?.login?.toLowerCase() === org.toLowerCase())
     // @ts-ignore
     .filter((repo) => canMerge(repo.permissions))
     // @ts-ignore
@@ -209,7 +210,7 @@ function bySeverityDesc (a, b) {
  * @returns {Promise<{ counts: Record<string, number> | null, failed: boolean }>}
  */
 async function countVulnerabilities (repo) {
-  const result = /** @type {{ success: boolean, stdout: string | undefined, stderr: string | undefined }} */ (await $(`gh api --paginate /repos/${ORG}/${repo}/dependabot/alerts?state=open&per_page=100`, {
+  const result = /** @type {{ success: boolean, stdout: string | undefined, stderr: string | undefined }} */ (await $(`gh api --paginate /repos/${requireGithubOrg()}/${repo}/dependabot/alerts?state=open&per_page=100`, {
     loading: false,
     reject: false,
     returnProperty: 'all'

--- a/src/commands/view/index.js
+++ b/src/commands/view/index.js
@@ -32,7 +32,7 @@ class PreviewCommand {
   }
 
   async fetchDeployInfo ({ currentCommitSha, owner, repo }) {
-    // gh api "https://api.github.com/repos/FieldControl/mountdoom/deployments?sha=826e5894db026d285be05748cdcfb848328033e6"
+    // gh api "https://api.github.com/repos/<owner>/<repo>/deployments?sha=<commit-sha>"
     const deployData = await $(`gh api https://api.github.com/repos/${owner}/${repo}/deployments?sha=${currentCommitSha}`)
       .then(JSON.parse)
 

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -34,8 +34,7 @@ const FSM_MAINTENANCE_TEAM_MEMBERS = [
 const QUALITY_TEAM = [
   'viniciusfantoli',
   'panegace',
-  'giovanalmeida2',
-  'QualidadeFieldControl'
+  'giovanalmeida2'
 ]
 
 const TEAMS = {

--- a/src/core/env.js
+++ b/src/core/env.js
@@ -11,5 +11,17 @@ dotEnv.config({
 })
 
 // Organização do GitHub usada nas consultas de PRs, checks e repositórios.
-// Configurável via .env para permitir o uso do theo fora da FieldControl.
-export const GITHUB_ORG = process.env.GITHUB_ORG || 'FieldControl'
+// Obrigatoriamente configurada via .env, sem valor padrão. Veja .env.example.
+export const GITHUB_ORG = process.env.GITHUB_ORG
+
+/**
+ * Retorna a organização configurada ou falha com uma mensagem acionável.
+ * @returns {string}
+ */
+export function requireGithubOrg () {
+  if (!GITHUB_ORG) {
+    throw new Error('GITHUB_ORG não configurada. Defina GITHUB_ORG no arquivo .env na raiz do projeto (veja .env.example).')
+  }
+
+  return GITHUB_ORG
+}

--- a/src/modules/merged-data.js
+++ b/src/modules/merged-data.js
@@ -3,7 +3,7 @@
 import { differenceInBusinessDays, format, parseISO } from 'date-fns'
 import { toZonedTime } from 'date-fns-tz'
 import { TEAMS } from '../core/constants.js'
-import { GITHUB_ORG } from '../core/env.js'
+import { requireGithubOrg } from '../core/env.js'
 import { githubFacade } from '../core/githubFacade.js'
 import { getTeamByAssignee } from '../utils/utils.js'
 
@@ -13,7 +13,7 @@ export async function fetchMergedPRs (team, from, to) {
   const pulls = await githubFacade.listPullRequestsV2({
     assignees,
     state: 'MERGED',
-    organization: GITHUB_ORG,
+    organization: requireGithubOrg(),
     from,
     to
   }).then((pulls) => {

--- a/src/modules/opened-data.js
+++ b/src/modules/opened-data.js
@@ -2,7 +2,7 @@
 
 import { format } from 'date-fns'
 import { QUALITY_TEAM, TEAMS } from '../core/constants.js'
-import { GITHUB_ORG } from '../core/env.js'
+import { requireGithubOrg } from '../core/env.js'
 import { githubFacade } from '../core/githubFacade.js'
 import { calcAge, hasPublishLabel, isApproved, isChecksPassed, isChecksInProgress, isMergeable, isNotFreelance, isNotWait, isQualityOk, isReady, isRejected } from '../utils/utils.js'
 
@@ -17,7 +17,7 @@ export async function fetchOpenedPRs (team) {
 
   const pulls = await githubFacade.listPullRequestsV2({
     assignees,
-    organization: GITHUB_ORG,
+    organization: requireGithubOrg(),
     state: 'OPEN',
     from,
     to

--- a/src/services/openai/open-ai-api.js
+++ b/src/services/openai/open-ai-api.js
@@ -4,8 +4,7 @@ export async function generateFieldNewsSuggestion ({ repoDescription, pullReques
   const prompt = `
     Comunique um e-mail descolado de uma alteração no código com descrição que deve ser explicativa para o público em geral.
 
-    Será enviado para funcionários internos da empresa Field Control.
-    Onde usamos "Fielders" para nos referirmos aos funcionários da empresa.
+    Será enviado para os funcionários internos da empresa.
 
     Deve possuir os seguintes tópicos separados:
 

--- a/test/utils/read-package-json.test.js
+++ b/test/utils/read-package-json.test.js
@@ -8,5 +8,5 @@ test('should read the package.json file and return tests content as a JSON objec
   const result = await readPackageJSON()
   assert.equal(result.name, 'theo')
   assert.equal(result.version, '1.0.0')
-  assert.equal(result.description, 'Kit com ferramentas e scripts para fluxos de trabalhos de desenvolvedores da field control')
+  assert.equal(result.description, 'Kit com ferramentas e scripts para fluxos de trabalho de desenvolvedores')
 })


### PR DESCRIPTION
<!-- markdownlint-configure-file
{
  "MD033": false,
  "MD036": false,
  "MD041": false
}
-->

✅ Closes

- —

✋ publicar antes deste pr

- —

⏭️ publicar depois deste pr

- —

**Checklist**

- [ ] Fieldnews - enviar broadcast via e-mail com publicação
- [ ] 🧪 Testes - testes e2e, integrados e unitários foram feitos

<!-- Init:FieldnewsEmailContent -->

**Contexto**

O `theo` é a CLI que a gente usa no dia a dia para abrir, revisar e mergear pull
requests. Ele nasceu dentro de um contexto específico, e por isso o nome da
empresa acabou espalhado pelo código: a organização do GitHub tinha o nome
chumbado como valor padrão, havia um usuário fixo na lista do time de qualidade,
e a descrição do pacote, o README e até o prompt de geração de e-mail citavam a
empresa diretamente.

**Motivações**

Um nome de organização embutido no código é uma amarra silenciosa: quem clona o
projeto para usar em outra org recebe consultas apontando para um lugar errado
sem nenhum aviso, e o `.env.example` sugeria que a variável era opcional quando
na prática ela é o que define de onde os dados vêm. Além disso, misturar o nome
da empresa com a lógica dificulta reaproveitar a ferramenta em qualquer outro
contexto.

O PR #444 já tinha dado o primeiro passo ao expor `GITHUB_ORG` via `.env`. Este
PR fecha o trabalho: tira o valor padrão e remove o que sobrou.

**Implementação**

- **`GITHUB_ORG` sem valor padrão.** `src/core/env.js` passa a expor também
  `requireGithubOrg()`, que devolve a org configurada ou lança um erro dizendo
  exatamente o que fazer (`defina GITHUB_ORG no .env, veja .env.example`).
  Os três consumidores — `repos`, `opened` e `merged` — passaram a usar essa
  função.
- **Resolução tardia no `repos`.** A constante `ORG` era lida no carregamento do
  módulo e usada no `.description()` do comando. Como o loader importa todos os
  comandos no boot, isso faria até um `theo --help` explodir quando a variável
  não estivesse definida. Agora a org é resolvida dentro das funções que
  realmente precisam dela.
- **`QualidadeFieldControl` removido do `QUALITY_TEAM`** em
  `src/core/constants.js`.
- **Prompt do fieldnews generalizado** em `src/services/openai/open-ai-api.js`.
- **Textos**: `package.json` (description e keywords), `README.md`,
  `CLAUDE.md`, `.env.example`, comentário de exemplo em `src/commands/view` e o
  teste que fixava a description.

Ficaram de fora de propósito, porque mexer neles quebraria comportamento: as
referências a **Fieldnews** (o `pr-create` lê `.github/workflows/fieldnews.yml` e
as tags `Init/End:FieldnewsEmailContent` dos repositórios-alvo), o handle
`LucasDelamura-Field` em `constants.js` e as palavras do cSpell em
`.vscode/settings.json`.

Preflight: o repositório não tem script `preflight`; rodei o equivalente —
`npm run lint` sem erros e `npm test` com 13/13 passando. Não foram adicionados
testes novos: a mudança é de configuração e texto, e o único teste tocado foi o
que fixava a description do `package.json`.

**Evoluções**

A ferramenta passa a ser agnóstica de organização — dá para usar em qualquer org
do GitHub só configurando o `.env`. E, principalmente, um `GITHUB_ORG` esquecido
agora falha na hora com uma mensagem que diz o que fazer, em vez de consultar
silenciosamente a organização errada e devolver uma lista vazia.

⚠️ **Atenção ao revisar:** remover `QualidadeFieldControl` do `QUALITY_TEAM`
**muda comportamento**. O `isQualityOk()` usado em `src/modules/opened-data.js`
não vai mais reconhecer aprovações dessa conta, então PRs aprovados por ela vão
aparecer como sem aprovação de qualidade no `theo opened`. Se a conta ainda
estiver ativa, o caminho melhor é mover a lista de qualidade para o `.env` em vez
de simplesmente apagar o usuário — me digam se preferem assim que eu ajusto.

**Screenshots**

Sem alteração visual — mudanças de configuração, texto e mensagens de erro.

<!-- End:FieldnewsEmailContent -->
